### PR TITLE
新增 DeepSeek 平台支持

### DIFF
--- a/macOS/KimiCodeBar.xcodeproj/project.pbxproj
+++ b/macOS/KimiCodeBar.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		FF4EC20D71184E45B29FFDB3C8BC6524 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 35A4DA7EE8214A199549CDB1B5E1C570 /* Sparkle */; };
 		FFAC0CE5E70E4F17AAD3B902 /* KimiCodeBarQuotaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F47923DD8C405BB3237AE1 /* KimiCodeBarQuotaService.swift */; };
 		7B1CA15E00000000000000000000A1 /* KimiLocalUsage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1CA15E00000000000000000000A2 /* KimiLocalUsage.swift */; };
+		B0A1C2D3E4F5A6B7C8D9E0F1A2B3C4D5 /* ProviderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A1C2D3E4F5A6B7C8D9E0F1A2B3C4D6 /* ProviderService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		EA0ACF1E9B564B769FE86518 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		c68dac1893a64de08b00b18830c9deba /* KimiWebLaunchAgentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiWebLaunchAgentManager.swift; sourceTree = "<group>"; };
 		7B1CA15E00000000000000000000A2 /* KimiLocalUsage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiLocalUsage.swift; sourceTree = "<group>"; };
+		B0A1C2D3E4F5A6B7C8D9E0F1A2B3C4D6 /* ProviderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +80,7 @@
 				E3B0FB687D9C4B9EB604A1EDB57506EC /* KimiArchiveManager.swift */,
 				D072D603E59C42A791F3136E0477FE56 /* ArchiveSettingsView.swift */,
 				7A11B22C33D44E55F660123B /* LanguageManager.swift */,
+				B0A1C2D3E4F5A6B7C8D9E0F1A2B3C4D6 /* ProviderService.swift */,
 				510792D7AE86479585E4504C /* Assets.xcassets */,
 				7A11B22C33D44E55F660123D /* Localizable.xcstrings */,
 				7D9C37304A73482ABB4CDE4D /* KimiCodeBar.entitlements */,
@@ -169,6 +172,7 @@
 				5495A4989471440499609844857244DC /* KimiArchiveManager.swift in Sources */,
 				C3C950D6204C47819C0011560E684C68 /* ArchiveSettingsView.swift in Sources */,
 				7A11B22C33D44E55F660123A /* LanguageManager.swift in Sources */,
+				B0A1C2D3E4F5A6B7C8D9E0F1A2B3C4D5 /* ProviderService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macOS/KimiCodeBar/KimiCodeBarApp.swift
+++ b/macOS/KimiCodeBar/KimiCodeBarApp.swift
@@ -171,7 +171,7 @@ struct KimiLabel: View {
     @StateObject private var languageManager = LanguageManager.shared
 
     var body: some View {
-        if let quota = model.quota {
+        if model.selectedProvider == .kimi, let quota = model.quota {
             Image(nsImage: MenuBarTextRenderer.image(
                 scheme: model.menuBarDisplayScheme,
                 weekly: quota.weekly.percentage,
@@ -732,6 +732,111 @@ struct KimiMenu: View {
             || sparkleUpdater.isUpdateReadyToRestart || model.pendingAppUpdateVersion != nil
     }
 
+    /// 当前平台是否正在加载
+    private var isProviderLoading: Bool {
+        switch model.selectedProvider {
+        case .kimi: return model.isLoading
+        case .deepseek: return model.deepseekState.isLoading
+        }
+    }
+
+    // MARK: - 平台 Tab 切换栏
+
+    private var providerTabBar: some View {
+        HStack(spacing: 6) {
+            ForEach(ProviderType.allCases) { provider in
+                providerTab(provider)
+            }
+        }
+        .padding(4)
+        .background(Color.kimiCardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func providerTab(_ provider: ProviderType) -> some View {
+        let isSelected = model.selectedProvider == provider
+        return Button(action: {
+            model.selectedProvider = provider
+        }) {
+            LText(provider.displayName)
+                .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
+                .foregroundStyle(isSelected ? .kimiTextPrimary : .kimiTextSecondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 7)
+                        .fill(isSelected ? Color.kimiTextPrimary.opacity(0.10) : .clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .cursor(.pointingHand)
+    }
+
+    // MARK: - Kimi 用量内容
+
+    private var kimiUsageContent: some View {
+        Group {
+            HStack(spacing: 12) {
+                UsageCard(
+                    title: languageManager.tr("本周用量"),
+                    subtitle: nil,
+                    percentage: model.quota?.weekly.percentage ?? 0,
+                    reset: model.quota?.weekly.timeUntilReset ?? "--",
+                    color: .kimiBlue,
+                    isLoading: model.isLoading
+                )
+
+                UsageCard(
+                    title: languageManager.tr("5小时用量"),
+                    subtitle: nil,
+                    percentage: model.quota?.fiveHour.percentage ?? 0,
+                    reset: model.quota?.fiveHour.timeUntilReset ?? "--",
+                    color: .orange,
+                    isLoading: model.isLoading
+                )
+            }
+
+            if model.showBoosterWalletCard {
+                BoosterWalletCard(
+                    wallet: model.quota?.boosterWallet,
+                    isLoading: model.isLoading
+                )
+            }
+
+            if model.showLocalUsageCard {
+                LocalUsageCard()
+            }
+        }
+    }
+
+    // MARK: - DeepSeek 余额内容
+
+    private var deepseekBalanceContent: some View {
+        let state = model.deepseekState
+        return Group {
+            if let balance = state.balance {
+                BalanceCard(
+                    providerName: "DeepSeek",
+                    balance: balance,
+                    isLoading: state.isLoading
+                )
+            } else if state.isLoading {
+                BalanceLoadingCard(providerName: "DeepSeek")
+            } else if let error = state.errorMessage {
+                BalanceErrorCard(
+                    providerName: "DeepSeek",
+                    message: error,
+                    consoleURL: ProviderType.deepseek.consoleURL
+                )
+            } else {
+                BalanceEmptyCard(
+                    providerName: "DeepSeek",
+                    consoleURL: ProviderType.deepseek.consoleURL
+                )
+            }
+        }
+    }
+
     var body: some View {
         VStack(spacing: 14) {
             // Header
@@ -749,54 +854,30 @@ struct KimiMenu: View {
                 CommunityButton(url: githubURL)
             }
 
-            // 用量卡片
+            // 平台切换 Tab
+            providerTabBar
+
+            // 用量内容
             VStack(spacing: 12) {
-                HStack(spacing: 12) {
-                    UsageCard(
-                        title: languageManager.tr("本周用量"),
-                        subtitle: nil,
-                        percentage: model.quota?.weekly.percentage ?? 0,
-                        reset: model.quota?.weekly.timeUntilReset ?? "--",
-                        color: .kimiBlue,
-                        isLoading: model.isLoading
-                    )
-
-                    UsageCard(
-                        title: languageManager.tr("5小时用量"),
-                        subtitle: nil,
-                        percentage: model.quota?.fiveHour.percentage ?? 0,
-                        reset: model.quota?.fiveHour.timeUntilReset ?? "--",
-                        color: .orange,
-                        isLoading: model.isLoading
-                    )
+                switch model.selectedProvider {
+                case .kimi:
+                    kimiUsageContent
+                case .deepseek:
+                    deepseekBalanceContent
                 }
-
-                if model.showBoosterWalletCard {
-                    BoosterWalletCard(
-                        wallet: model.quota?.boosterWallet,
-                        isLoading: model.isLoading
-                    )
-                }
-
-                // 本地用量卡片：扫描本地会话记录（wire.jsonl usage.record）得出 Token 消耗
-                if model.showLocalUsageCard {
-                    LocalUsageCard()
-                }
-
-                // Kimi Web 卡片及重启提示条临时屏蔽（2026-07）：Kimi 官方将 Kimi Web 改为
-                // 纯前端展示，且移除了 web kill 等管理命令，启停管理失去意义。
-                // KimiServerCard / KimiServerRestartHint / startKimiServer / stopKimiServer
-                // 等实现全部保留，恢复时把对应调用加回此处即可。
             }
 
             // 操作按钮卡片
             HStack(spacing: 8) {
                 ActionButton(
                     title: languageManager.tr("控制台"),
-                    textIcon: "KIMI",
+                    icon: model.selectedProvider == .kimi ? nil : "safari",
+                    textIcon: model.selectedProvider == .kimi ? "KIMI" : nil,
                     action: {
                         dismissMenuBarPanel()
-                        NSWorkspace.shared.open(consoleURL)
+                        if let url = model.selectedProvider.consoleURL {
+                            NSWorkspace.shared.open(url)
+                        }
                     }
                 )
 
@@ -804,7 +885,7 @@ struct KimiMenu: View {
                     title: languageManager.tr("刷新"),
                     icon: "arrow.clockwise",
                     action: { model.refreshAll() },
-                    disabled: !model.hasCredential || model.isLoading
+                    disabled: !model.hasCredential || (model.isLoading && model.selectedProvider == .kimi)
                 )
 
                 ActionButton(
@@ -821,8 +902,8 @@ struct KimiMenu: View {
                 )
             }
 
-            // KimiCode CLI 版本行：点击跳转官方更新日志；检测到新版本时无视设置强制显示
-            if shouldShowKimiVersionRow {
+            // KimiCode CLI 版本行：仅 Kimi 平台时显示；检测到新版本时无视设置强制显示
+            if model.selectedProvider == .kimi && shouldShowKimiVersionRow {
                 HStack(alignment: .center, spacing: 10) {
                     Text("KimiCode CLI")
                         .font(.system(size: 13, weight: .medium))
@@ -885,8 +966,8 @@ struct KimiMenu: View {
                 }
             }
 
-            // KimiCodeBar 版本行：点击跳转 GitHub Release；检测到新版本时无视设置强制显示
-            if shouldShowAppUpdateRow {
+            // KimiCodeBar 版本行：仅 Kimi 平台时显示；检测到新版本时无视设置强制显示
+            if model.selectedProvider == .kimi && shouldShowAppUpdateRow {
                 AppUpdateRow()
             }
         }
@@ -894,7 +975,7 @@ struct KimiMenu: View {
         .frame(width: 340)
         .background(Color.kimiPanelBackground)
         .overlay {
-            if !model.hasCredential {
+            if model.selectedProvider == .kimi && !model.hasCredential {
                 LoginOverlayView(isMenuVisible: isMenuVisible)
             }
         }
@@ -904,39 +985,41 @@ struct KimiMenu: View {
             if model.pendingUpdateVersion != nil {
                 showUpdateAlert = true
             }
-            Task {
-                await model.loadKimiVersion()
-                await model.checkForKimiCLIUpdate()
-                // 版本已追平（例如刚在外部更新完 CLI），关闭基于过期状态弹出的更新提示
-                if model.pendingUpdateVersion == nil {
-                    showUpdateAlert = false
+            if model.selectedProvider == .kimi {
+                Task {
+                    await model.loadKimiVersion()
+                    await model.checkForKimiCLIUpdate()
+                    if model.pendingUpdateVersion == nil {
+                        showUpdateAlert = false
+                    }
                 }
             }
+            model.refreshCurrentProvider(showsLoading: false)
         }
         .onChange(of: isMenuVisible) { _, isVisible in
             if isVisible {
                 isKimiServerRestartHintDismissed = false
-                Task { await model.refreshKimiServerState() }
-                // 面板打开立即刷新一次额度，但避免与正在进行的请求并发
-                if !model.isLoading {
-                    model.refresh(showsLoading: false)
+                if model.selectedProvider == .kimi {
+                    Task { await model.refreshKimiServerState() }
                 }
-                // 面板打开时探测 App 新版本，只更新状态、不弹窗
+                // 面板打开立即刷新当前平台数据
+                model.refreshCurrentProvider(showsLoading: false)
+                // 面板打开时探测 App 新版本
                 SparkleUpdater.shared.checkForUpdateInformation()
-                // 面板打开时扫描一次本地会话用量（后台线程，3 分钟节流）
-                KimiLocalUsageService.shared.refreshIfNeeded()
-                // 基于缓存快速判断是否需要弹窗
+                if model.selectedProvider == .kimi {
+                    KimiLocalUsageService.shared.refreshIfNeeded()
+                }
                 model.checkCachedKimiUpdate()
                 if model.pendingUpdateVersion != nil {
                     showUpdateAlert = true
                 }
-                // 刷新 KimiCode CLI 版本与更新状态
-                Task {
-                    await model.loadKimiVersion()
-                    await model.checkForKimiCLIUpdate()
-                    // 版本已追平（例如刚在外部更新完 CLI），关闭基于过期状态弹出的更新提示
-                    if model.pendingUpdateVersion == nil {
-                        showUpdateAlert = false
+                if model.selectedProvider == .kimi {
+                    Task {
+                        await model.loadKimiVersion()
+                        await model.checkForKimiCLIUpdate()
+                        if model.pendingUpdateVersion == nil {
+                            showUpdateAlert = false
+                        }
                     }
                 }
             }
@@ -3103,6 +3186,8 @@ struct BasicSettingsView: View {
 
     @State private var editingKey = ""
     @State private var isEditingKey = false
+    @State private var editingDeepseekKey = ""
+    @State private var isEditingDeepseekKey = false
     @State private var quotaIntervalText = "5"
     @State private var updateIntervalText = "30"
     @FocusState private var focusedField: APISettingField?
@@ -3214,6 +3299,17 @@ struct BasicSettingsView: View {
                             apiKeySection
                         }
                     }
+                }
+
+                // DeepSeek API Key
+                SettingsCard(title: "DeepSeek API Key") {
+                    providerKeySection(
+                        provider: .deepseek,
+                        key: $model.deepseekKey,
+                        editingState: $editingDeepseekKey,
+                        isEditing: $isEditingDeepseekKey,
+                        prefixHint: "sk-"
+                    )
                 }
 
                 // 外观主题
@@ -3346,6 +3442,8 @@ struct BasicSettingsView: View {
         .onAppear {
             editingKey = model.key
             isEditingKey = model.key.isEmpty
+            editingDeepseekKey = model.deepseekKey
+            isEditingDeepseekKey = false
             quotaIntervalText = intervalText(from: model.quotaRefreshInterval)
             updateIntervalText = intervalText(from: model.updateCheckInterval)
             launchAtLoginManager.refresh()
@@ -3394,6 +3492,84 @@ struct BasicSettingsView: View {
         let prefix = String(key.prefix(7))
         let suffix = String(key.suffix(5))
         return "\(prefix)...\(suffix)"
+    }
+
+    /// 第三方平台 API Key 输入区域
+    private func providerKeySection(
+        provider: ProviderType,
+        key: Binding<String>,
+        editingState: Binding<String>,
+        isEditing: Binding<Bool>,
+        prefixHint: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 12) {
+                if isEditing.wrappedValue {
+                    SecureField("\(prefixHint)...", text: editingState)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: .infinity)
+                        .onChange(of: editingState.wrappedValue) { _, newValue in
+                            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if trimmed != newValue {
+                                editingState.wrappedValue = trimmed
+                            }
+                        }
+                } else {
+                    Text(key.wrappedValue.isEmpty ? LanguageManager.tr("未配置") : maskedKey(key.wrappedValue))
+                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                        .foregroundStyle(key.wrappedValue.isEmpty ? .kimiTextTertiary : .kimiTextSecondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.kimiTextPrimary.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+
+                Button(action: {
+                    if isEditing.wrappedValue {
+                        saveProviderKey(provider: provider, key: key, editingState: editingState, isEditing: isEditing)
+                    } else {
+                        editingState.wrappedValue = key.wrappedValue
+                        isEditing.wrappedValue = true
+                    }
+                }) {
+                    LText(isEditing.wrappedValue ? "保存" : "修改")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.kimiBlue)
+                .disabled(isEditing.wrappedValue && editingState.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .cursor(isEditing.wrappedValue && editingState.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .arrow : .pointingHand)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 13)
+
+            SettingsCardDivider()
+            SettingsCardRow(
+                title: LanguageManager.tr("获取 API Key"),
+                subtitle: LanguageManager.tr("前往 %@ 控制台创建并复制 API Key。", arguments: [provider.displayName])
+            ) {
+                if let url = provider.consoleURL {
+                    LinkRow(
+                        title: LanguageManager.tr("去控制台"),
+                        icon: "arrow.up.right",
+                        url: url
+                    )
+                } else {
+                    EmptyView()
+                }
+            }
+        }
+    }
+
+    private func saveProviderKey(provider: ProviderType, key: Binding<String>, editingState: Binding<String>, isEditing: Binding<Bool>) {
+        let trimmed = editingState.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        editingState.wrappedValue = trimmed
+        key.wrappedValue = trimmed
+        isEditing.wrappedValue = false
+        commitIntervals()
+        if model.selectedProvider == provider {
+            model.refreshCurrentProvider(showsLoading: false)
+        }
     }
 }
 
@@ -4157,6 +4333,176 @@ extension View {
     }
 }
 
+// MARK: - 多平台余额卡片
+
+struct BalanceCard: View {
+    let providerName: String
+    let balance: ProviderBalance
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                LText("%@ 余额", providerName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.kimiTextPrimary)
+
+                Spacer()
+
+                Text(balance.isAvailable ? LanguageManager.tr("可用") : LanguageManager.tr("不可用"))
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(balance.isAvailable ? .green : .red)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background((balance.isAvailable ? Color.green : Color.red).opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(balance.currency == "CNY" ? "¥" : "$")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(.kimiTextSecondary)
+                Text(String(format: "%.2f", balance.totalBalance))
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .foregroundStyle(.kimiTextPrimary)
+                    .monospacedDigit()
+            }
+
+            if balance.grantedBalance > 0 || balance.toppedUpBalance > 0 {
+                VStack(spacing: 4) {
+                    if balance.grantedBalance > 0 {
+                        HStack {
+                            LText("赠送余额")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.kimiTextTertiary)
+                            Spacer()
+                            Text(String(format: "%.2f", balance.grantedBalance))
+                                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                .foregroundStyle(.kimiTextSecondary)
+                        }
+                    }
+                    if balance.toppedUpBalance > 0 {
+                        HStack {
+                            LText("充值余额")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.kimiTextTertiary)
+                            Spacer()
+                            Text(String(format: "%.2f", balance.toppedUpBalance))
+                                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                .foregroundStyle(.kimiTextSecondary)
+                        }
+                    }
+                }
+                .padding(10)
+                .background(Color.kimiTextPrimary.opacity(0.05))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.kimiCardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}
+
+struct BalanceLoadingCard: View {
+    let providerName: String
+
+    var body: some View {
+        VStack(spacing: 14) {
+            LText("%@ 余额", providerName)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.kimiTextPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            LoadingRing()
+                .frame(width: 28, height: 28)
+                .frame(maxWidth: .infinity)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity)
+        .background(Color.kimiCardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}
+
+struct BalanceErrorCard: View {
+    let providerName: String
+    let message: String
+    let consoleURL: URL?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                LText("%@ 余额", providerName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.kimiTextPrimary)
+                Spacer()
+            }
+
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundStyle(.red)
+
+            if let url = consoleURL {
+                Button(action: { NSWorkspace.shared.open(url) }) {
+                    LText("去控制台查看")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.kimiBlue)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.kimiBlue.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .cursor(.pointingHand)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.kimiCardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}
+
+struct BalanceEmptyCard: View {
+    let providerName: String
+    let consoleURL: URL?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                LText("%@ 余额", providerName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.kimiTextPrimary)
+                Spacer()
+            }
+
+            LText("请在设置中配置 API Key")
+                .font(.system(size: 12))
+                .foregroundStyle(.kimiTextSecondary)
+
+            if let url = consoleURL {
+                Button(action: { NSWorkspace.shared.open(url) }) {
+                    LText("获取 API Key")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.kimiBlue)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.kimiBlue.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .cursor(.pointingHand)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.kimiCardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}
+
 // MARK: - 登录方式
 
 enum LoginMethod: String, CaseIterable, Identifiable {
@@ -4227,6 +4573,10 @@ final class KimiCodeBarModel: ObservableObject {
     @AppStorage("cachedKimiReleaseNotes") var cachedKimiReleaseNotes: String = ""
     @AppStorage("snoozedKimiUpdateUntil") var snoozedKimiUpdateUntil: Double = 0
 
+    // MARK: - 多平台支持
+    @AppStorage("selectedProvider") var selectedProviderRaw: String = ProviderType.kimi.rawValue
+    @AppStorage("deepseekApiKey") var deepseekKey = ""
+
     // MARK: - 面板自定义（用户控制各卡片是否显示）
     @AppStorage("showBoosterWalletCard") var showBoosterWalletCard: Bool = true
     @AppStorage("showLocalUsageCard") var showLocalUsageCard: Bool = true
@@ -4254,6 +4604,15 @@ final class KimiCodeBarModel: ObservableObject {
 
     @Published var kimiServerState = KimiServerState()
 
+    // MARK: - 多平台状态
+    @Published var selectedProvider: ProviderType = .kimi {
+        didSet {
+            selectedProviderRaw = selectedProvider.rawValue
+            refreshCurrentProvider(showsLoading: false)
+        }
+    }
+    @Published var deepseekState = ProviderState()
+
     var hasCachedKimiUpdate: Bool {
         guard !cachedKimiLatestVersion.isEmpty, kimiVersion != LanguageManager.tr("未检测到"), kimiVersion != LanguageManager.tr("检测中…") else { return false }
         return compareVersions(normalizeVersion(kimiVersion), normalizeVersion(cachedKimiLatestVersion)) == .orderedAscending
@@ -4272,19 +4631,33 @@ final class KimiCodeBarModel: ObservableObject {
 
     private let service = KimiCodeBarQuotaService()
     private let oauthService = KimiOAuthService()
+    private let deepseekService = DeepSeekService()
     private var oauthLoginTask: Task<Void, Never>?
     private var timer: Timer?
     private var updateTimer: Timer?
 
-    /// 当前是否已配置可用凭证（决定菜单栏是否提示去设置）
+    /// 当前选中平台是否有可用凭证
     var hasCredential: Bool {
-        switch loginMethod {
-        case .token: return !key.isEmpty
-        case .oauth: return oauthToken != nil
+        switch selectedProvider {
+        case .kimi:
+            switch loginMethod {
+            case .token: return !key.isEmpty
+            case .oauth: return oauthToken != nil
+            }
+        case .deepseek: return !deepseekKey.isEmpty
+        }
+    }
+
+    /// 当前选中平台的 API Key（Token 登录模式或非 Kimi 平台）
+    var currentApiKey: String {
+        switch selectedProvider {
+        case .kimi: return key
+        case .deepseek: return deepseekKey
         }
     }
 
     init() {
+        selectedProvider = ProviderType(rawValue: selectedProviderRaw) ?? .kimi
         oauthToken = KimiOAuthService.loadStoredToken()
         refresh(showsLoading: false)
         Task { await loadKimiVersion() }
@@ -4297,7 +4670,7 @@ final class KimiCodeBarModel: ObservableObject {
         timer?.invalidate()
         let interval = max(1.0, quotaRefreshInterval) * 60
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-            Task { @MainActor in self.refresh(showsLoading: false) }
+            Task { @MainActor in self.refreshCurrentProvider(showsLoading: false) }
         }
         timer?.tolerance = interval * 0.1
     }
@@ -4316,11 +4689,21 @@ final class KimiCodeBarModel: ObservableObject {
         startUpdateTimer()
     }
 
-    /// 拉取额度用量。
-    /// - Parameter showsLoading: 是否把 isLoading 置 true 触发 UI loading 态。
-    ///   仅手动点「刷新」按钮时传 true；后台场景（启动、定时器、面板打开、切登录方式、
-    ///   设置窗口 onAppear、saveKey）一律传 false，避免界面无谓闪烁。
+    /// 拉取当前选中平台的用量/余额。
+    func refreshCurrentProvider(showsLoading: Bool = true) {
+        switch selectedProvider {
+        case .kimi: refreshKimi(showsLoading: showsLoading)
+        case .deepseek: refreshDeepSeek(showsLoading: showsLoading)
+        }
+    }
+
+    /// 拉取 Kimi 额度用量（兼容旧调用方）。
     func refresh(showsLoading: Bool = true) {
+        refreshKimi(showsLoading: showsLoading)
+    }
+
+    /// 拉取 Kimi 额度用量。
+    private func refreshKimi(showsLoading: Bool = true) {
         if showsLoading {
             isLoading = true
         }
@@ -4360,9 +4743,73 @@ final class KimiCodeBarModel: ObservableObject {
                     if self.quota == nil {
                         self.text = "--"
                     }
-                    self.errorMessage = errorDescription(error)
+                    self.errorMessage = kimiErrorDescription(error)
                 }
             }
+        }
+    }
+
+    /// 拉取 DeepSeek 余额。
+    private func refreshDeepSeek(showsLoading: Bool = true) {
+        guard !deepseekKey.isEmpty else {
+            deepseekState = ProviderState(errorMessage: LanguageManager.tr("未配置 API Key"))
+            text = "DS --"
+            return
+        }
+
+        if showsLoading {
+            deepseekState.isLoading = true
+        }
+        deepseekState.errorMessage = nil
+
+        Task {
+            let result = await deepseekService.fetchBalance(apiKey: deepseekKey)
+            await MainActor.run {
+                deepseekState.isLoading = false
+                switch result {
+                case .success(let balance):
+                    deepseekState.balance = balance
+                    deepseekState.errorMessage = nil
+                    let amount = formatBalanceShort(balance.totalBalance)
+                    text = "DS \(amount)"
+                case .failure(let error):
+                    deepseekState.errorMessage = providerErrorDescription(error, provider: .deepseek)
+                    if deepseekState.balance == nil {
+                        text = "DS --"
+                    }
+                }
+            }
+        }
+    }
+
+    private func formatBalanceShort(_ amount: Double) -> String {
+        if amount >= 1000 {
+            return String(format: "%.1fk", amount / 1000)
+        }
+        return String(format: "%.0f", amount)
+    }
+
+    private func providerErrorDescription(_ error: ProviderError, provider: ProviderType) -> String {
+        switch error {
+        case .invalidKeyFormat:
+            return LanguageManager.tr("API Key 无效，请检查是否已正确配置")
+        case .badURL:
+            return LanguageManager.tr("请求地址无效")
+        case .networkError(let msg):
+            return LanguageManager.tr("网络错误：%@", arguments: [msg])
+        case .httpError(let code, let msg):
+            return LanguageManager.tr("%1$@ API 返回错误（%2$@）：%3$@", arguments: [provider.displayName, "\(code)", msg])
+        case .badResponse:
+            return LanguageManager.tr("无法解析 API 返回数据")
+        }
+    }
+
+    func refreshAll() {
+        refreshCurrentProvider()
+        Task {
+            await checkForKimiCLIUpdate()
+            await checkForAppUpdate()
+            await refreshKimiServerState()
         }
     }
 
@@ -4502,15 +4949,6 @@ final class KimiCodeBarModel: ObservableObject {
             return LanguageManager.tr("已取消授权")
         case .timeout:
             return LanguageManager.tr("授权超时，请重新发起授权")
-        }
-    }
-
-    func refreshAll() {
-        refresh()
-        Task {
-            await checkForKimiCLIUpdate()
-            await checkForAppUpdate()
-            await refreshKimiServerState()
         }
     }
 
@@ -4926,7 +5364,7 @@ final class KimiCodeBarModel: ObservableObject {
         }.value
     }
 
-    private func errorDescription(_ error: QuotaError) -> String {
+    private func kimiErrorDescription(_ error: QuotaError) -> String {
         switch error {
         case .invalidKeyFormat:
             return LanguageManager.tr("API Key 格式错误，应以 sk-kimi- 开头")

--- a/macOS/KimiCodeBar/Localizable.xcstrings
+++ b/macOS/KimiCodeBar/Localizable.xcstrings
@@ -1,2164 +1,2245 @@
 {
-  "sourceLanguage" : "zh-Hans",
-  "strings" : {
-    "" : {
-
-    },
-    "--" : {
-
-    },
-    "-- · --" : {
-
-    },
-    "·" : {
-
-    },
-    "/" : {
-
-    },
-    "## 检查更新接口错误反馈\n\n错误信息：\n```\n%1$@\n```\n\n请补充以下信息：\n- 当前 KimiCodeBar 版本：%2$@\n- 当前网络环境：\n- 问题描述：\n" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "## Update check API error report\n\nError message:\n```\n%1$@\n```\n\nPlease add the following information:\n- Current KimiCodeBar version: %2$@\n- Current network environment:\n- Problem description:\n"
+  "sourceLanguage": "zh-Hans",
+  "strings": {
+    "": {},
+    "--": {},
+    "-- · --": {},
+    "·": {},
+    "/": {},
+    "## 检查更新接口错误反馈\n\n错误信息：\n```\n%1$@\n```\n\n请补充以下信息：\n- 当前 KimiCodeBar 版本：%2$@\n- 当前网络环境：\n- 问题描述：\n": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "## Update check API error report\n\nError message:\n```\n%1$@\n```\n\nPlease add the following information:\n- Current KimiCodeBar version: %2$@\n- Current network environment:\n- Problem description:\n"
           }
         }
       }
     },
-    "%1$d天%2$d小时后重置" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resets in %1$dd %2$dh"
+    "%1$d天%2$d小时后重置": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resets in %1$dd %2$dh"
           }
         }
       }
     },
-    "%1$d小时%2$d分钟后重置" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resets in %1$dh %2$dm"
+    "%1$d小时%2$d分钟后重置": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resets in %1$dh %2$dm"
           }
         }
       }
     },
-    "%d分钟后重置" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resets in %dm"
+    "%d分钟后重置": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resets in %dm"
           }
         }
       }
     },
-    "%lld" : {
-
-    },
-    "%lld%%" : {
-
-    },
-    "5H" : {
-
+    "%lld": {},
+    "%lld%%": {},
+    "5H": {},
+    "5小时用量": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5-Hour Usage"
+          }
+        }
+      }
     },
-    "5小时用量" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5-Hour Usage"
+    "7D": {},
+    "API Key 格式错误，应以 sk-kimi- 开头": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid API Key format. The key should start with sk-kimi-"
           }
         }
       }
     },
-    "7D" : {
-
+    "GitHub Release 接口请求失败：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Release API request failed: %@"
+          }
+        }
+      }
     },
-    "API Key 格式错误，应以 sk-kimi- 开头" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid API Key format. The key should start with sk-kimi-"
+    "GitHub Release 接口返回异常状态码：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The GitHub Release API returned an unexpected status code: %@"
           }
         }
       }
     },
-    "GitHub Release 接口请求失败：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub Release API request failed: %@"
+    "GitHub Release 接口返回数据解析失败：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to parse the GitHub Release API response: %@"
           }
         }
       }
     },
-    "GitHub Release 接口返回异常状态码：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The GitHub Release API returned an unexpected status code: %@"
+    "K 前缀": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "K Prefix"
           }
         }
       }
     },
-    "GitHub Release 接口返回数据解析失败：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to parse the GitHub Release API response: %@"
+    "Kimi": {},
+    "Kimi API 返回错误（%1$@）：%2$@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kimi API returned an error (%1$@): %2$@"
           }
         }
       }
     },
-    "K 前缀" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "K Prefix"
+    "Kimi Web": {},
+    "Kimi Web 运行版本 %1$@ 低于已安装版本 %2$@，建议重启服务。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kimi Web is running %1$@, which is older than the installed %2$@. A restart is recommended."
           }
         }
       }
     },
-    "Kimi" : {
-
+    "Kimi 前缀": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kimi Prefix"
+          }
+        }
+      }
     },
-    "Kimi API 返回错误（%1$@）：%2$@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kimi API returned an error (%1$@): %2$@"
+    "Kimi 登录": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in with Kimi"
           }
         }
       }
     },
-    "Kimi Web" : {
-
+    "KimiCode %@": {},
+    "KimiCode %@ 已发布，点击更新。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KimiCode %@ is available. Click to update."
+          }
+        }
+      }
     },
-    "Kimi Web 运行版本 %1$@ 低于已安装版本 %2$@，建议重启服务。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kimi Web is running %1$@, which is older than the installed %2$@. A restart is recommended."
+    "KimiCode %1$@ 可供下载，您现在的版本是 %2$@。要现在下载吗？": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KimiCode %1$@ is available—you're now running %2$@. Do you want to download it now?"
           }
         }
       }
     },
-    "Kimi 前缀" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kimi Prefix"
+    "KimiCode Bar": {},
+    "KimiCode Bar 设置": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KimiCode Bar Settings"
           }
         }
       }
     },
-    "Kimi 登录" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with Kimi"
+    "KimiCode CLI": {},
+    "KimiCode CLI %@": {},
+    "KimiCode 有新版本": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New KimiCode Version Available"
           }
         }
       }
     },
-    "KimiCode %@" : {
-
+    "KimiCodeBar": {},
+    "KimiCodeBar %1$@ 已发布，您现在的版本是 %2$@。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KimiCodeBar %1$@ is available—you're now running %2$@."
+          }
+        }
+      }
     },
-    "KimiCode %@ 已发布，点击更新。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KimiCode %@ is available. Click to update."
+    "KimiCodeBar 完全开源，代码公开透明。欢迎 Star、提交 Issue 或参与共建，让这款工具变得更好。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KimiCodeBar is fully open source with transparent code. Stars, issues, and contributions are welcome—help make it better."
           }
         }
       }
     },
-    "KimiCode %1$@ 可供下载，您现在的版本是 %2$@。要现在下载吗？" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KimiCode %1$@ is available—you're now running %2$@. Do you want to download it now?"
+    "Open Source": {},
+    "sk-kimi-...": {},
+    "Token 登录": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in with Token"
           }
         }
       }
     },
-    "KimiCode Bar" : {
-
+    "v%@": {},
+    "一个月以后": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Month"
+          }
+        }
+      }
     },
-    "KimiCode Bar 设置" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KimiCode Bar Settings"
+    "一周以后": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Week"
           }
         }
       }
     },
-    "KimiCode CLI" : {
-
+    "一天以后": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Day"
+          }
+        }
+      }
     },
-    "KimiCode CLI %@" : {
-
+    "上次自动归档：%1$@，共 %2$d 个会话": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last auto-archive: %1$@ · %2$d sessions"
+          }
+        }
+      }
     },
-    "KimiCode 有新版本" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New KimiCode Version Available"
+    "下载新版本": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download New Version"
           }
         }
       }
     },
-    "KimiCodeBar" : {
-
+    "为 Kimi Code 量身设计的用量监控小工具，在菜单栏轻量化运行，限额一目了然。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A usage monitor designed for Kimi Code. It lives in your menu bar and keeps your limits at a glance."
+          }
+        }
+      }
     },
-    "KimiCodeBar %1$@ 已发布，您现在的版本是 %2$@。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KimiCodeBar %1$@ is available—you're now running %2$@."
+    "会话列表": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions"
           }
         }
       }
     },
-    "KimiCodeBar 完全开源，代码公开透明。欢迎 Star、提交 Issue 或参与共建，让这款工具变得更好。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KimiCodeBar is fully open source with transparent code. Stars, issues, and contributions are welcome—help make it better."
+    "保存": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         }
       }
     },
-    "Open Source" : {
-
+    "修改": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit"
+          }
+        }
+      }
     },
-    "sk-kimi-..." : {
-
+    "停止": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        }
+      }
     },
-    "Token 登录" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with Token"
+    "免费版": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Free"
           }
         }
       }
     },
-    "v%@" : {
-
+    "全部": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
+          }
+        }
+      }
     },
-    "一个月以后" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Month"
+    "关于": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         }
       }
     },
-    "一周以后" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Week"
+    "其他登录方式": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other Sign-in Methods"
           }
         }
       }
     },
-    "一天以后" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Day"
+    "分钟": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "min"
           }
         }
       }
     },
-    "上次自动归档：%1$@，共 %2$d 个会话" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last auto-archive: %1$@ · %2$d sessions"
+    "刷新": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
           }
         }
       }
     },
-    "下载新版本" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download New Version"
+    "前往 Kimi 控制台创建并复制 API Key。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create and copy an API Key in the Kimi console."
           }
         }
       }
     },
-    "为 Kimi Code 量身设计的用量监控小工具，在菜单栏轻量化运行，限额一目了然。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A usage monitor designed for Kimi Code. It lives in your menu bar and keeps your limits at a glance."
+    "加油包余额": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Booster Pack Balance"
           }
         }
       }
     },
-    "会话列表" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sessions"
+    "单行": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Single Line"
           }
         }
       }
     },
-    "保存" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "即将重置": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting soon"
           }
         }
       }
     },
-    "修改" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit"
+    "去 GitHub 反馈": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report on GitHub"
           }
         }
       }
     },
-    "停止" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+    "去授权": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorize"
           }
         }
       }
     },
-    "免费版" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Free"
+    "去控制台": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Console"
           }
         }
       }
     },
-    "全部" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All"
+    "反馈问题": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report an Issue"
           }
         }
       }
     },
-    "关于" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+    "发现新版本": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Version Available"
           }
         }
       }
     },
-    "其他登录方式" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Other Sign-in Methods"
+    "取消": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         }
       }
     },
-    "分钟" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "min"
+    "取消归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unarchive"
           }
         }
       }
     },
-    "刷新" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh"
+    "启动": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
           }
         }
       }
     },
-    "前往 Kimi 控制台创建并复制 API Key。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create and copy an API Key in the Kimi console."
+    "启用自动归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Auto Archive"
           }
         }
       }
     },
-    "加油包余额" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Booster Pack Balance"
+    "周 %1$d%% · 5h %2$d%%": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7D %1$d%% · 5H %2$d%%"
           }
         }
       }
     },
-    "单行" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Single Line"
+    "周%1$d%% 5h %2$d%%": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "W %1$d%% · 5H %2$d%%"
           }
         }
       }
     },
-    "即将重置" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resetting soon"
+    "在 Finder 中显示": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal in Finder"
           }
         }
       }
     },
-    "去 GitHub 反馈" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report on GitHub"
+    "基本设置": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         }
       }
     },
-    "去授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorize"
+    "基础版": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basic"
           }
         }
       }
     },
-    "去控制台" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Console"
+    "复制": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
           }
         }
       }
     },
-    "反馈问题" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report an Issue"
+    "复制错误信息": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Error Message"
           }
         }
       }
     },
-    "发现新版本" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Version Available"
+    "外观主题": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
           }
         }
       }
     },
-    "取消" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "安装更新": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install Update"
           }
         }
       }
     },
-    "取消归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unarchive"
+    "实时预览": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live Preview"
           }
         }
       }
     },
-    "启动" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+    "已停止": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopped"
           }
         }
       }
     },
-    "启用自动归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Auto Archive"
+    "已取消授权": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization canceled"
           }
         }
       }
     },
-    "周 %1$d%% · 5h %2$d%%" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7D %1$d%% · 5H %2$d%%"
+    "已启用": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
           }
         }
       }
     },
-    "周%1$d%% 5h %2$d%%" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "W %1$d%% · 5H %2$d%%"
+    "已复制": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
           }
         }
       }
     },
-    "在 Finder 中显示" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reveal in Finder"
+    "已归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archived"
           }
         }
       }
     },
-    "基本设置" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+    "已成功归档 %d 个会话。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archived %d sessions."
           }
         }
       }
     },
-    "基础版" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basic"
+    "已授权 Kimi 账号": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kimi Account Authorized"
           }
         }
       }
     },
-    "复制" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy"
+    "开启后，KimiCodeBar 会每小时检查一次本地 Kimi Code 会话，将超过保留期限且未归档的会话自动标记为归档。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, KimiCodeBar checks local Kimi Code sessions every hour and automatically archives sessions that have passed the retention period."
           }
         }
       }
     },
-    "复制错误信息" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Error Message"
+    "开机自动启动": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch at Login"
           }
         }
       }
     },
-    "外观主题" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appearance"
+    "异常": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         }
       }
     },
-    "安装更新" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install Update"
+    "归档于 %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archived %@"
           }
         }
       }
     },
-    "实时预览" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Live Preview"
+    "归档完成": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archive Complete"
           }
         }
       }
     },
-    "已停止" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stopped"
+    "归档期限": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archive After"
           }
         }
       }
     },
-    "已取消授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization canceled"
+    "当前最新": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up to Date"
           }
         }
       }
     },
-    "已启用" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enabled"
+    "待归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending"
           }
         }
       }
     },
-    "已复制" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied"
+    "忽略本次更新": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore This Version"
           }
         }
       }
     },
-    "已归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archived"
+    "总对话": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total"
           }
         }
       }
     },
-    "已成功归档 %d 个会话。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archived %d sessions."
+    "手动填写 API Key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter an API Key manually"
           }
         }
       }
     },
-    "已授权 Kimi 账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kimi Account Authorized"
+    "打开": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open"
           }
         }
       }
     },
-    "开启后，KimiCodeBar 会每小时检查一次本地 Kimi Code 会话，将超过保留期限且未归档的会话自动标记为归档。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When enabled, KimiCodeBar checks local Kimi Code sessions every hour and automatically archives sessions that have passed the retention period."
+    "打开授权页": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Authorization Page"
           }
         }
       }
     },
-    "开机自动启动" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launch at Login"
+    "技能包通常位于 ~/.kimi-code/skills/": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skill packages are usually located in ~/.kimi-code/skills/"
           }
         }
       }
     },
-    "异常" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+    "技能管理": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skills"
           }
         }
       }
     },
-    "归档于 %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archived %@"
+    "授权已失效，请重新登录": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization is no longer valid. Please sign in again."
           }
         }
       }
     },
-    "归档完成" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archive Complete"
+    "授权服务返回错误（%1$@）：%2$@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization service returned an error (%1$@): %2$@"
           }
         }
       }
     },
-    "归档期限" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archive After"
+    "授权登录": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in with Browser"
           }
         }
       }
     },
-    "当前最新" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Up to Date"
+    "授权码": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization Code"
           }
         }
       }
     },
-    "待归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pending"
+    "授权码 %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization code: %@"
           }
         }
       }
     },
-    "忽略本次更新" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignore This Version"
+    "授权码已过期，请重新发起授权": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The authorization code expired. Please start a new authorization."
           }
         }
       }
     },
-    "总对话" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total"
+    "授权被拒绝": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization was denied"
           }
         }
       }
     },
-    "手动填写 API Key" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter an API Key manually"
+    "授权请求地址无效": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid authorization request URL"
           }
         }
       }
     },
-    "打开" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open"
+    "授权超时，请重新发起授权": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization timed out. Please start a new authorization."
           }
         }
       }
     },
-    "打开授权页" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Authorization Page"
+    "控制台": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Console"
           }
         }
       }
     },
-    "技能包通常位于 ~/.kimi-code/skills/" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skill packages are usually located in ~/.kimi-code/skills/"
+    "提交反馈": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Feedback"
           }
         }
       }
     },
-    "技能管理" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skills"
+    "数据仅本地存储，所有 API 只与 Kimi 官方通信，代码全部开源可审计。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data is stored locally only. All requests go directly to Kimi's official APIs, and the code is fully open source."
           }
         }
       }
     },
-    "授权已失效，请重新登录" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization is no longer valid. Please sign in again."
+    "新版": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Version"
           }
         }
       }
     },
-    "授权服务返回错误（%1$@）：%2$@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization service returned an error (%1$@): %2$@"
+    "新版本的 KimiCode 已经发布": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A new version of KimiCode is available"
           }
         }
       }
     },
-    "授权登录" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with Browser"
+    "无法解析 API 返回数据": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to parse the API response"
           }
         }
       }
     },
-    "授权码" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization Code"
+    "无法解析授权服务返回数据": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to parse the authorization service response"
           }
         }
       }
     },
-    "授权码 %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization code: %@"
+    "无法读取会话目录：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to read session directory: %@"
           }
         }
       }
     },
-    "授权码已过期，请重新发起授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The authorization code expired. Please start a new authorization."
+    "无限制": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlimited"
           }
         }
       }
     },
-    "授权被拒绝" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization was denied"
+    "日志接口请求失败：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changelog API request failed: %@"
           }
         }
       }
     },
-    "授权请求地址无效" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid authorization request URL"
+    "日志接口返回内容中未找到版本信息": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No version information found in the changelog API response"
           }
         }
       }
     },
-    "授权超时，请重新发起授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization timed out. Please start a new authorization."
+    "日志接口返回内容无法解析": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to parse the changelog API response"
           }
         }
       }
     },
-    "控制台" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Console"
+    "日志接口返回异常状态码：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The changelog API returned an unexpected status code: %@"
           }
         }
       }
     },
-    "提交反馈" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send Feedback"
+    "显示样式": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display Style"
           }
         }
       }
     },
-    "数据仅本地存储，所有 API 只与 Kimi 官方通信，代码全部开源可审计。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data is stored locally only. All requests go directly to Kimi's official APIs, and the code is fully open source."
+    "暂无已安装技能": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Skills Installed"
           }
         }
       }
     },
-    "新版" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Version"
+    "暂无更新记录。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No update history available."
           }
         }
       }
     },
-    "新版本的 KimiCode 已经发布" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A new version of KimiCode is available"
+    "暂无符合条件的会话": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Sessions to Archive"
           }
         }
       }
     },
-    "无法解析 API 返回数据" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to parse the API response"
+    "更新于 %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updated %@"
           }
         }
       }
     },
-    "无法解析授权服务返回数据" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to parse the authorization service response"
+    "更新内容": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What's New"
           }
         }
       }
     },
-    "无法读取会话目录：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to read session directory: %@"
+    "更新到 %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update to %@"
           }
         }
       }
     },
-    "无限制" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unlimited"
+    "月之亮面": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
           }
         }
       }
     },
-    "日志接口请求失败：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changelog API request failed: %@"
+    "月之暗面": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
           }
         }
       }
     },
-    "日志接口返回内容中未找到版本信息" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No version information found in the changelog API response"
+    "服务未运行": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Service is not running"
           }
         }
       }
     },
-    "日志接口返回内容无法解析" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to parse the changelog API response"
+    "未启用": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disabled"
           }
         }
       }
     },
-    "日志接口返回异常状态码：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The changelog API returned an unexpected status code: %@"
+    "未归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unarchived"
           }
         }
       }
     },
-    "显示样式" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display Style"
+    "未授权": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Authorized"
           }
         }
       }
     },
-    "暂无已安装技能" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Skills Installed"
+    "未检测到": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Detected"
           }
         }
       }
     },
-    "暂无更新记录。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No update history available."
+    "未登录": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Signed In"
           }
         }
       }
     },
-    "暂无符合条件的会话" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Sessions to Archive"
+    "未知": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
           }
         }
       }
     },
-    "更新于 %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updated %@"
+    "本周用量": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekly Usage"
           }
         }
       }
     },
-    "更新内容" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "What's New"
+    "本月消费": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spent This Month"
           }
         }
       }
     },
-    "更新到 %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update to %@"
+    "查看仓库": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Repository"
           }
         }
       }
     },
-    "月之亮面" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light"
+    "查看更新": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Updates"
           }
         }
       }
     },
-    "月之暗面" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark"
+    "检查更新…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates…"
           }
         }
       }
     },
-    "服务未运行" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Service is not running"
+    "检查更新失败": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Check Failed"
           }
         }
       }
     },
-    "未启用" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disabled"
+    "检查更新接口错误反馈": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update check API error report"
           }
         }
       }
     },
-    "未归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unarchived"
+    "检查更新间隔": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Check Interval"
           }
         }
       }
     },
-    "未授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Authorized"
+    "检测中": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking"
           }
         }
       }
     },
-    "未检测到" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Detected"
+    "检测中…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking…"
           }
         }
       }
     },
-    "未登录" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Signed In"
+    "正在加载内容…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading content…"
           }
         }
       }
     },
-    "未知" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unknown"
+    "正在加载技能…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading skills…"
           }
         }
       }
     },
-    "本周用量" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weekly Usage"
+    "正在加载更新内容…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading release notes…"
           }
         }
       }
     },
-    "本月消费" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spent This Month"
+    "没有符合条件的会话": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching sessions"
           }
         }
       }
     },
-    "查看仓库" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Repository"
+    "浏览器一键授权": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One-click authorization in your browser"
           }
         }
       }
     },
-    "查看更新" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Updates"
+    "版本 %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
           }
         }
       }
     },
-    "检查更新…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check for Updates…"
+    "版本接口请求失败：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version API request failed: %@"
           }
         }
       }
     },
-    "检查更新失败" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update Check Failed"
+    "版本接口返回内容中未找到版本号": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No version number found in the version API response"
           }
         }
       }
     },
-    "检查更新接口错误反馈" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update check API error report"
+    "版本接口返回内容无法解析": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to parse the version API response"
           }
         }
       }
     },
-    "检查更新间隔" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update Check Interval"
+    "版本接口返回异常状态码：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The version API returned an unexpected status code: %@"
           }
         }
       }
     },
-    "检测中" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking"
+    "登录后查看 Kimi 用量": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in to view your Kimi usage"
           }
         }
       }
     },
-    "检测中…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking…"
+    "登录方式": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign-in Method"
           }
         }
       }
     },
-    "正在加载内容…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading content…"
+    "确定": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         }
       }
     },
-    "正在加载技能…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading skills…"
+    "社区开源版": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Community Edition"
           }
         }
       }
     },
-    "正在加载更新内容…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading release notes…"
+    "社区版": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         }
       }
     },
-    "没有符合条件的会话" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No matching sessions"
+    "稍后再说": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
           }
         }
       }
     },
-    "浏览器一键授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "One-click authorization in your browser"
+    "立即归档 %d 个会话": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archive %d Sessions Now"
           }
         }
       }
     },
-    "版本 %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@"
+    "立即扫描": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan Now"
           }
         }
       }
     },
-    "版本接口请求失败：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version API request failed: %@"
+    "立即重启": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Now"
           }
         }
       }
     },
-    "版本接口返回内容中未找到版本号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No version number found in the version API response"
+    "等待授权中": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for authorization"
           }
         }
       }
     },
-    "版本接口返回内容无法解析" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to parse the version API response"
+    "等待浏览器授权…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for browser authorization…"
           }
         }
       }
     },
-    "版本接口返回异常状态码：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The version API returned an unexpected status code: %@"
+    "网络错误：%@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network error: %@"
           }
         }
       }
     },
-    "登录后查看 Kimi 用量" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in to view your Kimi usage"
+    "自动归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Archive"
           }
         }
       }
     },
-    "登录方式" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign-in Method"
+    "获取 API Key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get API Key"
           }
         }
       }
     },
-    "确定" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "菜单栏样式": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu Bar Style"
           }
         }
       }
     },
-    "社区开源版" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Community Edition"
+    "设置": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         }
       }
     },
-    "社区版" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+    "语言": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
           }
         }
       }
     },
-    "稍后再说" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Later"
+    "请求地址无效": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid request URL"
           }
         }
       }
     },
-    "立即归档 %d 个会话" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archive %d Sessions Now"
+    "超过保留期限的会话将被自动归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions past the retention period will be archived automatically"
           }
         }
       }
     },
-    "立即扫描" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan Now"
+    "超过该时间未更新的会话会被归档": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions not updated within this period will be archived"
           }
         }
       }
     },
-    "立即重启" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restart Now"
+    "跟随系统": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
           }
         }
       }
     },
-    "等待授权中" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for authorization"
+    "运行中": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running"
           }
         }
       }
     },
-    "等待浏览器授权…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for browser authorization…"
+    "近期更新日志": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recent Updates"
           }
         }
       }
     },
-    "网络错误：%@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network error: %@"
+    "进阶版": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intermediate"
           }
         }
       }
     },
-    "自动归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Archive"
+    "退出": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
           }
         }
       }
     },
-    "获取 API Key" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get API Key"
+    "退出登录": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign Out"
           }
         }
       }
     },
-    "菜单栏样式" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menu Bar Style"
+    "选择上方技能以预览内容": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a skill above to preview its content"
           }
         }
       }
     },
-    "设置" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+    "重启": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart"
           }
         }
       }
     },
-    "语言" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Language"
+    "重启完成更新": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart to Update"
           }
         }
       }
     },
-    "请求地址无效" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid request URL"
+    "量身定制": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tailor-Made"
           }
         }
       }
     },
-    "超过保留期限的会话将被自动归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sessions past the retention period will be archived automatically"
+    "隐私安全": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy & Security"
           }
         }
       }
     },
-    "超过该时间未更新的会话会被归档" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sessions not updated within this period will be archived"
+    "额度刷新间隔": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quota Refresh Interval"
           }
         }
       }
     },
-    "跟随系统" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
+    "高级版": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advanced"
           }
         }
       }
     },
-    "运行中" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running"
+    "默认样式": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
           }
         }
       }
     },
-    "近期更新日志" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recent Updates"
+    "面板自定义": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panel Customization"
           }
         }
       }
     },
-    "进阶版" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intermediate"
+    "加油包余额卡片": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Booster Pack Card"
           }
         }
       }
     },
-    "退出" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+    "Kimi Web 卡片": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kimi Web Card"
           }
         }
       }
     },
-    "退出登录" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign Out"
+    "官方砍掉了 server 服务，临时弃用。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The official server service was removed. Temporarily deprecated."
           }
         }
       }
     },
-    "选择上方技能以预览内容" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select a skill above to preview its content"
+    "KimiCode CLI 版本号": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KimiCode CLI Version"
           }
         }
       }
     },
-    "重启" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restart"
+    "勾选要在菜单栏面板中显示的内容，取消勾选可隐藏对应卡片。设置即时生效。": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check the items you want to show in the menu bar panel. Uncheck to hide the corresponding card. Changes take effect immediately."
           }
         }
       }
     },
-    "重启完成更新" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restart to Update"
+    "KimiCodeBar 版本行": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KimiCodeBar Version Row"
           }
         }
       }
     },
-    "量身定制" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tailor-Made"
+    "发现更新": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Available"
           }
         }
       }
     },
-    "隐私安全" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy & Security"
+    "本地用量": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Usage"
           }
         }
       }
     },
-    "额度刷新间隔" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quota Refresh Interval"
+    "本地用量卡片": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Usage Card"
           }
         }
       }
     },
-    "高级版" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advanced"
+    "累计": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total"
           }
         }
       }
     },
-    "默认样式" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default"
+    "今日": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Today"
           }
         }
       }
     },
-    "面板自定义" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Panel Customization"
+    "7天": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7D"
           }
         }
       }
     },
-    "加油包余额卡片" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Booster Pack Card"
+    "使用 Token": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token Used"
           }
         }
       }
     },
-    "Kimi Web 卡片" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kimi Web Card"
+    "缓存命中率": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache Hit Rate"
           }
         }
       }
     },
-    "官方砍掉了 server 服务，临时弃用。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The official server service was removed. Temporarily deprecated."
+    "暂无会话记录": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Session Records"
           }
         }
       }
     },
-    "KimiCode CLI 版本号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KimiCode CLI Version"
+    "发现新版本时会强制显示": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always shown when a new version is available"
           }
         }
       }
     },
-    "勾选要在菜单栏面板中显示的内容，取消勾选可隐藏对应卡片。设置即时生效。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check the items you want to show in the menu bar panel. Uncheck to hide the corresponding card. Changes take effect immediately."
+    "未配置 API Key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Key not configured"
           }
         }
       }
     },
-    "KimiCodeBar 版本行" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KimiCodeBar Version Row"
+    "API Key 无效，请检查是否已正确配置": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid API Key, please check configuration"
           }
         }
       }
     },
-    "发现更新" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update Available"
+    "%@ 余额": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Balance"
           }
         }
       }
     },
-    "本地用量" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local Usage"
+    "可用": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available"
           }
         }
       }
     },
-    "本地用量卡片" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local Usage Card"
+    "不可用": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unavailable"
           }
         }
       }
     },
-    "累计" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total"
+    "赠送余额": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Granted Balance"
           }
         }
       }
     },
-    "今日" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Today"
+    "充值余额": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Topped-up Balance"
           }
         }
       }
     },
-    "7天" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7D"
+    "%1$@ API 返回错误（%2$@）：%3$@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ API error (%2$@): %3$@"
           }
         }
       }
     },
-    "使用 Token" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Token Used"
+    "未配置": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not configured"
           }
         }
       }
     },
-    "缓存命中率" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache Hit Rate"
+    "去控制台查看": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View in Console"
           }
         }
       }
     },
-    "暂无会话记录" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Session Records"
+    "前往 %@ 控制台创建并复制 API Key。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to the %@ console to create and copy your API Key."
           }
         }
       }
     },
-    "发现新版本时会强制显示" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always shown when a new version is available"
+    "请在设置中配置 API Key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please configure API Key in Settings"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/macOS/KimiCodeBar/ProviderService.swift
+++ b/macOS/KimiCodeBar/ProviderService.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+// MARK: - 平台类型
+
+enum ProviderType: String, CaseIterable, Identifiable {
+    case kimi
+    case deepseek
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .kimi: return "Kimi"
+        case .deepseek: return "DeepSeek"
+        }
+    }
+
+    /// 菜单栏缩写
+    var menuBarAbbreviation: String {
+        switch self {
+        case .kimi: return "Kimi"
+        case .deepseek: return "DS"
+        }
+    }
+
+    /// API Key 前缀提示（用于格式校验）
+    var apiKeyPrefix: String {
+        switch self {
+        case .kimi: return "sk-kimi-"
+        case .deepseek: return "sk-"
+        }
+    }
+
+    var baseURL: String {
+        switch self {
+        case .kimi: return "https://api.kimi.com"
+        case .deepseek: return "https://api.deepseek.com"
+        }
+    }
+
+    var consoleURL: URL? {
+        switch self {
+        case .kimi: return URL(string: "https://www.kimi.com/code/console")
+        case .deepseek: return URL(string: "https://platform.deepseek.com/api_keys")
+        }
+    }
+}
+
+// MARK: - 平台余额
+
+struct ProviderBalance: Equatable {
+    let provider: ProviderType
+    let totalBalance: Double
+    let currency: String
+    let grantedBalance: Double
+    let toppedUpBalance: Double
+    let isAvailable: Bool
+}
+
+// MARK: - 平台状态
+
+struct ProviderState {
+    var balance: ProviderBalance?
+    var isLoading = false
+    var errorMessage: String?
+}
+
+// MARK: - 平台错误
+
+enum ProviderError: Error {
+    case invalidKeyFormat
+    case networkError(String)
+    case httpError(statusCode: Int, message: String)
+    case badResponse
+    case badURL
+}
+
+// MARK: - 平台服务协议
+
+protocol ProviderServiceProtocol {
+    var provider: ProviderType { get }
+    func fetchBalance(apiKey: String) async -> Result<ProviderBalance, ProviderError>
+}
+
+// MARK: - DeepSeek 服务
+
+/// GET https://api.deepseek.com/user/balance
+/// Authorization: Bearer {apiKey}
+final class DeepSeekService: ProviderServiceProtocol {
+    let provider: ProviderType = .deepseek
+
+    func fetchBalance(apiKey: String) async -> Result<ProviderBalance, ProviderError> {
+        guard let url = URL(string: "https://api.deepseek.com/user/balance") else {
+            return .failure(.badResponse)
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: 30)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .failure(.badResponse)
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                if httpResponse.statusCode == 401 {
+                    return .failure(.invalidKeyFormat)
+                }
+                return .failure(.httpError(statusCode: httpResponse.statusCode, message: body))
+            }
+
+            struct BalanceInfo: Codable {
+                let currency: String
+                let totalBalance: String
+                let grantedBalance: String
+                let toppedUpBalance: String
+
+                enum CodingKeys: String, CodingKey {
+                    case currency
+                    case totalBalance = "total_balance"
+                    case grantedBalance = "granted_balance"
+                    case toppedUpBalance = "topped_up_balance"
+                }
+            }
+
+            struct BalanceResponse: Codable {
+                let isAvailable: Bool
+                let balanceInfos: [BalanceInfo]
+
+                enum CodingKeys: String, CodingKey {
+                    case isAvailable = "is_available"
+                    case balanceInfos = "balance_infos"
+                }
+            }
+
+            let balanceResponse = try JSONDecoder().decode(BalanceResponse.self, from: data)
+            let primary = balanceResponse.balanceInfos.first
+
+            return .success(ProviderBalance(
+                provider: .deepseek,
+                totalBalance: primary.flatMap { Double($0.totalBalance) } ?? 0,
+                currency: primary?.currency ?? "CNY",
+                grantedBalance: primary.flatMap { Double($0.grantedBalance) } ?? 0,
+                toppedUpBalance: primary.flatMap { Double($0.toppedUpBalance) } ?? 0,
+                isAvailable: balanceResponse.isAvailable
+            ))
+        } catch is DecodingError {
+            return .failure(.badResponse)
+        } catch {
+            return .failure(.networkError(error.localizedDescription))
+        }
+    }
+}
+


### PR DESCRIPTION
- 新增 ProviderService.swift：ProviderType / ProviderBalance / ProviderState 抽象， DeepSeekService 通过 GET /user/balance 查询余额（含赠送、充值分项）
- 菜单栏面板新增平台 Tab 切换栏（Kimi / DeepSeek）
- 新增 BalanceCard / BalanceLoadingCard / BalanceErrorCard / BalanceEmptyCard 组件
- 设置页新增 DeepSeek API Key 配置区
- 菜单栏图标适配当前平台：Kimi 保持 7D/5H，DeepSeek 显示 DS ¥xx
- 登录蒙版仅 Kimi 平台触发，DeepSeek 无 Key 时引导去控制台获取
- 同步 Localizable.xcstrings 英文翻译