### PR TITLE
docs: 清理 README 底部重复徽章与空标题

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,9 @@
 
 ### 🛠 系统适配
 
-- MacOS（已发布）
+- macOS（已发布）
 - Windows（已发布，由 @JYH1878 维护）
 
 #
 
 ### 欢迎提交 👉 <a href="https://github.com/xifandev/KimiCodeBar/issues">Issues</a> 反馈问题或建议
-
-#
-
-###
-
-  <img src="https://img.shields.io/badge/-KIMI%E7%A4%BE%E5%8C%BA%E7%89%88-orange" alt="社区版">
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/xifandev/KimiCodeBar" alt="License"></a>

--- a/README_EN.md
+++ b/README_EN.md
@@ -57,10 +57,3 @@ All data is stored locally. APIs only communicate with official Kimi servers. Th
 #
 
 ### Feedback 👉 <a href="https://github.com/xifandev/KimiCodeBar/issues">Issues</a>
-
-#
-
-###
-
-  <img src="https://img.shields.io/badge/-KIMI%20Community%20Edition-orange" alt="Community Edition">
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/xifandev/KimiCodeBar" alt="License"></a>


### PR DESCRIPTION
本次改动仅涉及文档：

- 移除中英文 README 底部无意义的 ### 空标题
- 删除底部重复的 License / 社区版徽章（顶部已存在）
- 统一中文 README 中 macOS 的大小写

不影响应用功能。