### PR TITLE
新增多账号配额监控：支持添加、切换与管理多个 Kimi 账号

### DIFF
--- a/macOS/KimiCodeBar.xcodeproj/project.pbxproj
+++ b/macOS/KimiCodeBar.xcodeproj/project.pbxproj
@@ -12,10 +12,12 @@
 		4f9dbf90dffc49ad85242801801d170f /* KimiWebLaunchAgentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = c68dac1893a64de08b00b18830c9deba /* KimiWebLaunchAgentManager.swift */; };
 		5495A4989471440499609844857244DC /* KimiArchiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B0FB687D9C4B9EB604A1EDB57506EC /* KimiArchiveManager.swift */; };
 		71B3F9A2C4D84E5B0F1A6C8D /* KimiOAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4D2C7B1A5F48E3B6D09A21 /* KimiOAuthService.swift */; };
+		7B1CA15E00000000000000000000B1 /* KimiAccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1CA15E00000000000000000000B2 /* KimiAccountStore.swift */; };
 		7A11B22C33D44E55F660123A /* LanguageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B22C33D44E55F660123B /* LanguageManager.swift */; };
 		7A11B22C33D44E55F660123C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 7A11B22C33D44E55F660123D /* Localizable.xcstrings */; };
 		B9C4D489692D416CA7616C08D907965F /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528728E8E55940FC93765F944AFE050F /* SparkleUpdater.swift */; };
 		C3C950D6204C47819C0011560E684C68 /* ArchiveSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D072D603E59C42A791F3136E0477FE56 /* ArchiveSettingsView.swift */; };
+		7A11B22C33D44E55F660125A /* AccountsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B22C33D44E55F660125B /* AccountsSettingsView.swift */; };
 		FF4EC20D71184E45B29FFDB3C8BC6524 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 35A4DA7EE8214A199549CDB1B5E1C570 /* Sparkle */; };
 		FFAC0CE5E70E4F17AAD3B902 /* KimiCodeBarQuotaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F47923DD8C405BB3237AE1 /* KimiCodeBarQuotaService.swift */; };
 		7B1CA15E00000000000000000000A1 /* KimiLocalUsage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1CA15E00000000000000000000A2 /* KimiLocalUsage.swift */; };
@@ -30,7 +32,9 @@
 		7A11B22C33D44E55F660123D /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		7D9C37304A73482ABB4CDE4D /* KimiCodeBar.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KimiCodeBar.entitlements; sourceTree = "<group>"; };
 		9E4D2C7B1A5F48E3B6D09A21 /* KimiOAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiOAuthService.swift; sourceTree = "<group>"; };
+		7B1CA15E00000000000000000000B2 /* KimiAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiAccountStore.swift; sourceTree = "<group>"; };
 		D072D603E59C42A791F3136E0477FE56 /* ArchiveSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveSettingsView.swift; sourceTree = "<group>"; };
+		7A11B22C33D44E55F660125B /* AccountsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsSettingsView.swift; sourceTree = "<group>"; };
 		D44CECE74D174CC298CE6FE7 /* KimiCodeBar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KimiCodeBar.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3B0FB687D9C4B9EB604A1EDB57506EC /* KimiArchiveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiArchiveManager.swift; sourceTree = "<group>"; };
 		EA0ACF1E9B564B769FE86518 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -75,8 +79,10 @@
 				c68dac1893a64de08b00b18830c9deba /* KimiWebLaunchAgentManager.swift */,
 				02F47923DD8C405BB3237AE1 /* KimiCodeBarQuotaService.swift */,
 				9E4D2C7B1A5F48E3B6D09A21 /* KimiOAuthService.swift */,
+				7B1CA15E00000000000000000000B2 /* KimiAccountStore.swift */,
 				E3B0FB687D9C4B9EB604A1EDB57506EC /* KimiArchiveManager.swift */,
 				D072D603E59C42A791F3136E0477FE56 /* ArchiveSettingsView.swift */,
+				7A11B22C33D44E55F660125B /* AccountsSettingsView.swift */,
 				7A11B22C33D44E55F660123B /* LanguageManager.swift */,
 				510792D7AE86479585E4504C /* Assets.xcassets */,
 				7A11B22C33D44E55F660123D /* Localizable.xcstrings */,
@@ -166,8 +172,10 @@
 				4f9dbf90dffc49ad85242801801d170f /* KimiWebLaunchAgentManager.swift in Sources */,
 				FFAC0CE5E70E4F17AAD3B902 /* KimiCodeBarQuotaService.swift in Sources */,
 				71B3F9A2C4D84E5B0F1A6C8D /* KimiOAuthService.swift in Sources */,
+				7B1CA15E00000000000000000000B1 /* KimiAccountStore.swift in Sources */,
 				5495A4989471440499609844857244DC /* KimiArchiveManager.swift in Sources */,
 				C3C950D6204C47819C0011560E684C68 /* ArchiveSettingsView.swift in Sources */,
+				7A11B22C33D44E55F660125A /* AccountsSettingsView.swift in Sources */,
 				7A11B22C33D44E55F660123A /* LanguageManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macOS/KimiCodeBar/AccountsSettingsView.swift
+++ b/macOS/KimiCodeBar/AccountsSettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // MARK: - 账号设置页
 
-/// 设置窗口「账号」页：管理多账号（列表 / 设主 / 重命名 / 删除 / 重新授权 / 添加账号）。
+/// 设置窗口「多账号」页：管理多账号（列表 / 设主 / 重命名 / 删除 / 重新授权 / 添加账号）。
 /// 数据全部来自 KimiCodeBarModel.shared（Phase 1 多账号数据层）。
 struct AccountsSettingsView: View {
     @StateObject private var model = KimiCodeBarModel.shared
@@ -26,7 +26,7 @@ struct AccountsSettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                LText("账号")
+                LText("多账号")
                     .font(.system(size: 22, weight: .bold))
                     .foregroundStyle(.kimiTextPrimary)
 

--- a/macOS/KimiCodeBar/AccountsSettingsView.swift
+++ b/macOS/KimiCodeBar/AccountsSettingsView.swift
@@ -1,0 +1,468 @@
+import SwiftUI
+
+// MARK: - 账号设置页
+
+/// 设置窗口「账号」页：管理多账号（列表 / 设主 / 重命名 / 删除 / 重新授权 / 添加账号）。
+/// 数据全部来自 KimiCodeBarModel.shared（Phase 1 多账号数据层）。
+struct AccountsSettingsView: View {
+    @StateObject private var model = KimiCodeBarModel.shared
+    @StateObject private var languageManager = LanguageManager.shared
+
+    // 重命名弹窗状态
+    @State private var renamingAccount: KimiAccount?
+    @State private var renameText = ""
+    @State private var showRenameAlert = false
+
+    // 删除确认弹窗状态
+    @State private var accountPendingDeletion: KimiAccount?
+    @State private var showDeleteConfirm = false
+
+    /// 是否展示「添加账号」卡片：
+    /// 有账号、授权流程进行中、或授权失败有待展示的错误时展示。
+    private var showsAddAccountCard: Bool {
+        !model.accounts.isEmpty || model.oauthLoginInProgress || model.oauthLoginError != nil
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                LText("账号")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(.kimiTextPrimary)
+
+                // 账号列表
+                SettingsCard(title: languageManager.tr("账号列表")) {
+                    if model.accounts.isEmpty {
+                        emptyState
+                    } else {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(model.accounts) { account in
+                                AccountRow(
+                                    displayName: model.displayName(for: account),
+                                    isPrimary: account.id == model.primaryAccountID,
+                                    state: model.accountStates[account.id] ?? .idle,
+                                    membershipLevel: model.accountQuotas[account.id]?.membershipLevel,
+                                    reauthorizeDisabled: model.oauthLoginInProgress,
+                                    onSetPrimary: { model.setPrimaryAccount(account.id) },
+                                    onRename: {
+                                        renamingAccount = account
+                                        renameText = account.alias ?? ""
+                                        showRenameAlert = true
+                                    },
+                                    onDelete: {
+                                        accountPendingDeletion = account
+                                        showDeleteConfirm = true
+                                    },
+                                    onReauthorize: { model.reauthorizeAccount(account.id) }
+                                )
+
+                                if account.id != model.accounts.last?.id {
+                                    SettingsCardDivider()
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+
+                // 添加账号 / 授权引导
+                if showsAddAccountCard {
+                    SettingsCard {
+                        VStack(alignment: .leading, spacing: 0) {
+                            if model.oauthLoginInProgress, let auth = model.oauthDeviceAuth {
+                                AddAccountAuthorizingView(auth: auth)
+                            } else {
+                                addAccountRow
+                            }
+
+                            if let error = model.oauthLoginError {
+                                SettingsCardDivider()
+                                ErrorMessageView(message: error)
+                                    .padding(.horizontal, 16)
+                                    .padding(.vertical, 12)
+                            }
+                        }
+                    }
+                }
+
+                // 说明文案
+                LText("账号仅用于在 Bar 中查看配额，不影响 Kimi CLI 的登录状态。")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.kimiTextSecondary)
+                    .padding(.horizontal, 4)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 44)
+            .padding(.bottom, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color.kimiPanelBackground)
+        .alert(LanguageManager.tr("重命名账号"), isPresented: $showRenameAlert) {
+            TextField(LanguageManager.tr("别名"), text: $renameText)
+            Button(LanguageManager.tr("保存")) {
+                if let account = renamingAccount {
+                    // 空白别名 = 清除别名，恢复默认「账号 N」
+                    model.renameAccount(account.id, alias: renameText)
+                }
+            }
+            Button(LanguageManager.tr("取消"), role: .cancel) {}
+        } message: {
+            Text(LanguageManager.tr("为该账号设置一个便于区分的别名，留空则恢复默认名称。"))
+        }
+        .alert(LanguageManager.tr("删除账号"), isPresented: $showDeleteConfirm) {
+            Button(LanguageManager.tr("删除"), role: .destructive) {
+                if let account = accountPendingDeletion {
+                    model.removeAccount(account.id)
+                }
+            }
+            Button(LanguageManager.tr("取消"), role: .cancel) {}
+        } message: {
+            if let account = accountPendingDeletion {
+                Text(LanguageManager.tr(
+                    "确定删除「%1$@」吗？只会删除 Bar 中保存的授权，不影响 Kimi CLI 的登录状态。",
+                    arguments: [model.displayName(for: account)]
+                ))
+            }
+        }
+    }
+
+    // MARK: 空状态
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "person.crop.circle.badge.plus")
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(.kimiTextTertiary)
+
+            LText("还没有添加账号")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.kimiTextPrimary)
+
+            LText("添加账号后，即可在菜单栏查看各账号的配额使用情况")
+                .font(.system(size: 12))
+                .foregroundStyle(.kimiTextSecondary)
+
+            AccountPrimaryButton(
+                title: languageManager.tr("添加账号"),
+                disabled: model.oauthLoginInProgress
+            ) {
+                model.startOAuthLogin()
+            }
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+    }
+
+    // MARK: 添加账号入口行
+
+    private var addAccountRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "person.badge.plus")
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(.kimiTextTertiary)
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 3) {
+                LText("添加账号")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.kimiTextPrimary)
+
+                LText("通过浏览器授权添加一个 Kimi 账号")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.kimiTextSecondary)
+            }
+
+            Spacer()
+
+            if model.oauthLoginInProgress {
+                // 已发起授权、等待设备授权码返回中
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                AccountPrimaryButton(title: languageManager.tr("添加账号")) {
+                    model.startOAuthLogin()
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 13)
+    }
+}
+
+// MARK: - 账号行
+
+private struct AccountRow: View {
+    let displayName: String
+    let isPrimary: Bool
+    let state: KimiAccountState
+    let membershipLevel: String?
+    let reauthorizeDisabled: Bool
+    let onSetPrimary: () -> Void
+    let onRename: () -> Void
+    let onDelete: () -> Void
+    let onReauthorize: () -> Void
+
+    @StateObject private var languageManager = LanguageManager.shared
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(displayName)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.kimiTextPrimary)
+                        .lineLimit(1)
+
+                    if isPrimary {
+                        StatusTag(text: languageManager.tr("主账号"), color: .kimiBlue)
+                    }
+
+                    if let membershipLevel, !membershipLevel.isEmpty {
+                        StatusTag(text: membershipLevel, color: .purple)
+                    }
+
+                    if case .unauthorized = state {
+                        StatusTag(text: languageManager.tr("登录失效"), color: .red)
+                    }
+                }
+
+                statusLine
+            }
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                if case .unauthorized = state {
+                    AccountActionButton(
+                        title: languageManager.tr("重新授权"),
+                        color: .kimiBlue,
+                        hoveredColor: .kimiBlue,
+                        disabled: reauthorizeDisabled,
+                        action: onReauthorize
+                    )
+                }
+
+                AccountActionButton(
+                    title: languageManager.tr("设为主账号"),
+                    disabled: isPrimary,
+                    action: onSetPrimary
+                )
+
+                AccountActionButton(
+                    title: languageManager.tr("重命名"),
+                    action: onRename
+                )
+
+                AccountActionButton(
+                    title: languageManager.tr("删除"),
+                    destructive: true,
+                    action: onDelete
+                )
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: 状态行
+
+    @ViewBuilder
+    private var statusLine: some View {
+        switch state {
+        case .loading:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+
+                LText("加载中…")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.kimiTextSecondary)
+            }
+        case .failed(let message):
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundStyle(.orange.opacity(0.9))
+                .lineLimit(1)
+        default:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - 添加账号授权引导
+
+/// 设备授权流程进行中的引导界面：授权码 + 复制 + 打开授权页 + 取消。
+/// 视觉对齐 BasicSettingsView 的 OAuth 授权中区域。
+private struct AddAccountAuthorizingView: View {
+    let auth: KimiDeviceAuthorization
+
+    @StateObject private var model = KimiCodeBarModel.shared
+
+    @State private var isHoveredCancel = false
+    @State private var isHoveredCopyCode = false
+    @State private var isHoveredReopen = false
+    @State private var isCodeCopied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 状态行
+            HStack(spacing: 10) {
+                LoadingRing()
+                    .frame(width: 16, height: 16)
+
+                LText("等待浏览器授权…")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.kimiTextPrimary)
+
+                Spacer()
+
+                Button(action: { model.cancelOAuthLogin() }) {
+                    LText("取消")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(isHoveredCancel ? .kimiTextPrimary : .kimiTextSecondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(isHoveredCancel ? Color.kimiTextPrimary.opacity(0.14) : Color.kimiTextPrimary.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .cursor(.pointingHand)
+                .onHover { isHoveredCancel = $0 }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 13)
+
+            SettingsCardDivider()
+
+            // 授权码行
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    LText("授权码")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.kimiTextSecondary)
+
+                    Text(auth.userCode)
+                        .font(.system(size: 20, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.kimiTextPrimary)
+                        .textSelection(.enabled)
+                }
+
+                Spacer()
+
+                Button(action: {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(auth.userCode, forType: .string)
+                    isCodeCopied = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        isCodeCopied = false
+                    }
+                }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: isCodeCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 11, weight: .medium))
+                        LText(isCodeCopied ? "已复制" : "复制")
+                            .font(.system(size: 12, weight: .medium))
+                    }
+                    .foregroundStyle(isHoveredCopyCode ? .kimiTextPrimary : .kimiTextSecondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(isHoveredCopyCode ? Color.kimiTextPrimary.opacity(0.14) : Color.kimiTextPrimary.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .cursor(.pointingHand)
+                .onHover { isHoveredCopyCode = $0 }
+
+                if let urlString = auth.displayURL, let url = URL(string: urlString) {
+                    Button(action: { NSWorkspace.shared.open(url) }) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "safari")
+                                .font(.system(size: 11, weight: .medium))
+                            LText("打开授权页")
+                                .font(.system(size: 12, weight: .medium))
+                        }
+                        .foregroundStyle(isHoveredReopen ? .white : .white.opacity(0.9))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(isHoveredReopen ? Color.kimiBlue.opacity(0.85) : Color.kimiBlue)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                    .buttonStyle(.plain)
+                    .cursor(.pointingHand)
+                    .onHover { isHoveredReopen = $0 }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 13)
+        }
+    }
+}
+
+// MARK: - 主按钮（蓝色）
+
+private struct AccountPrimaryButton: View {
+    let title: String
+    var disabled: Bool = false
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 7)
+                .background(disabled ? Color.kimiBlue.opacity(0.6) : (isHovered ? Color.kimiBlue.opacity(0.85) : Color.kimiBlue))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .cursor(disabled ? .arrow : .pointingHand)
+        .onHover { isHovered = $0 }
+    }
+}
+
+// MARK: - 行操作按钮
+
+/// 账号行内的小号操作按钮：悬停高亮 + 手型光标；禁用态降低视觉权重并恢复箭头光标。
+private struct AccountActionButton: View {
+    let title: String
+    var color: Color = .kimiTextSecondary
+    var hoveredColor: Color = .kimiTextPrimary
+    var destructive: Bool = false
+    var disabled: Bool = false
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(foreground)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(background)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .cursor(disabled ? .arrow : .pointingHand)
+        .onHover { isHovered = $0 }
+    }
+
+    private var foreground: Color {
+        if disabled { return .kimiTextTertiary }
+        if destructive { return isHovered ? .red.opacity(0.9) : .red }
+        return isHovered ? hoveredColor : color
+    }
+
+    private var background: Color {
+        if disabled { return Color.kimiTextPrimary.opacity(0.04) }
+        if destructive { return isHovered ? Color.red.opacity(0.18) : Color.red.opacity(0.12) }
+        return isHovered ? Color.kimiTextPrimary.opacity(0.14) : Color.kimiTextPrimary.opacity(0.08)
+    }
+}

--- a/macOS/KimiCodeBar/KimiAccountStore.swift
+++ b/macOS/KimiCodeBar/KimiAccountStore.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+// MARK: - 账号模型
+
+/// 一个 Kimi 账号：OAuth token + 用户别名 + 可选的账号唯一标识（添加时去重用）。
+struct KimiAccount: Codable, Equatable, Identifiable {
+    var id: UUID
+    /// 用户自定义别名；为空时界面回退显示「账号 N」
+    var alias: String?
+    var token: KimiOAuthToken
+    /// 账号唯一标识（来自 usages 接口 user 对象，如 id/phone/email；取不到为 nil，仅做尽力去重）
+    var accountIdentifier: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case alias
+        case token
+        case accountIdentifier = "account_identifier"
+    }
+}
+
+// MARK: - 账号状态
+
+/// 单个账号的配额加载状态
+enum KimiAccountState: Equatable {
+    /// 尚未加载
+    case idle
+    /// 加载中
+    case loading
+    /// 正常（配额已就绪）
+    case loaded
+    /// 加载失败（网络等原因），附带失败原因
+    case failed(String)
+    /// 登录失效（refresh_token 被吊销等），保留凭证等待用户重新授权
+    case unauthorized
+}
+
+// MARK: - 账号存储
+
+/// 多账号凭证存储：accounts 数组 + 主账号 ID，持久化到 credentials.json。
+/// 旧版单 token 格式读取时自动迁移为一个账号并设为主账号。
+/// 所有写操作在锁内串行完成并原子落盘，避免多账号并行刷新 token 时写文件竞争。
+final class KimiAccountStore {
+    static let shared = KimiAccountStore()
+
+    /// credentials.json 的磁盘格式（账号数组 + 主账号 ID）
+    struct FileFormat: Codable, Equatable {
+        var accounts: [KimiAccount]
+        var primaryAccountID: UUID?
+
+        enum CodingKeys: String, CodingKey {
+            case accounts
+            case primaryAccountID = "primary_account_id"
+        }
+    }
+
+    private let lock = NSLock()
+    private var fileFormat: FileFormat
+
+    private init() {
+        let loaded = Self.loadFromDisk()
+        fileFormat = loaded?.format ?? FileFormat(accounts: [], primaryAccountID: nil)
+        // 旧格式迁移成功，立即以新格式落盘
+        if loaded?.migrated == true {
+            saveLocked()
+        }
+    }
+
+    // MARK: 路径
+
+    /// Bar 专属的凭证存储路径（与旧单 token 文件相同）。
+    /// 注意：刻意与 KimiCode CLI 的 ~/.kimi-code/credentials/kimi-code.json 隔离，
+    /// Bar 的授权、刷新、删除账号都只操作本文件，绝不读写 CLI 的凭证，
+    /// 避免因 refresh_token 服务端轮换导致 CLI 凭证失效。
+    static func credentialsFileURL() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("KimiCodeBar/credentials.json")
+    }
+
+    // MARK: 读取
+
+    /// 当前内存中的账号快照
+    var snapshot: FileFormat {
+        lock.lock()
+        defer { lock.unlock() }
+        return fileFormat
+    }
+
+    func account(id: UUID) -> KimiAccount? {
+        snapshot.accounts.first(where: { $0.id == id })
+    }
+
+    /// 从磁盘重读（含旧格式迁移），覆盖内存状态。
+    /// 用于刷新周期开始时同步其他 Bar 实例的写入。
+    func reload() {
+        guard let loaded = Self.loadFromDisk() else { return }
+        lock.lock()
+        fileFormat = loaded.format
+        if loaded.migrated {
+            saveLocked()
+        }
+        lock.unlock()
+    }
+
+    /// 直接从磁盘读取单个账号（不动内存状态）。
+    /// 用于「刷新 token 前再读一次磁盘」的防御逻辑（按账号维度）。
+    func freshAccount(id: UUID) -> KimiAccount? {
+        Self.loadFromDisk()?.format.accounts.first(where: { $0.id == id })
+    }
+
+    // MARK: 写入（全部串行 + 原子落盘）
+
+    func addAccount(_ account: KimiAccount) {
+        mutate { $0.accounts.append(account) }
+    }
+
+    /// 删除账号；若删除的是主账号，仅清空主账号 ID，顺延策略由调用方决定
+    func removeAccount(id: UUID) {
+        mutate {
+            $0.accounts.removeAll(where: { $0.id == id })
+            if $0.primaryAccountID == id {
+                $0.primaryAccountID = nil
+            }
+        }
+    }
+
+    func updateToken(id: UUID, token: KimiOAuthToken) {
+        mutate { format in
+            guard let index = format.accounts.firstIndex(where: { $0.id == id }) else { return }
+            format.accounts[index].token = token
+        }
+    }
+
+    func updateAccountIdentifier(id: UUID, identifier: String?) {
+        mutate { format in
+            guard let index = format.accounts.firstIndex(where: { $0.id == id }) else { return }
+            format.accounts[index].accountIdentifier = identifier
+        }
+    }
+
+    func setAlias(id: UUID, alias: String?) {
+        mutate { format in
+            guard let index = format.accounts.firstIndex(where: { $0.id == id }) else { return }
+            format.accounts[index].alias = alias
+        }
+    }
+
+    func setPrimaryAccount(_ id: UUID?) {
+        mutate { $0.primaryAccountID = id }
+    }
+
+    /// 主账号兜底：主账号 ID 为空或已不存在时，顺延为第一个账号；无账号时清空
+    func ensurePrimaryAccount() {
+        lock.lock()
+        let before = fileFormat
+        if fileFormat.accounts.isEmpty {
+            fileFormat.primaryAccountID = nil
+        } else {
+            let valid = fileFormat.primaryAccountID.flatMap { pid in
+                fileFormat.accounts.contains(where: { $0.id == pid }) ? pid : nil
+            }
+            if valid == nil {
+                fileFormat.primaryAccountID = fileFormat.accounts.first?.id
+            }
+        }
+        if fileFormat != before {
+            saveLocked()
+        }
+        lock.unlock()
+    }
+
+    // MARK: 私有
+
+    /// 串行化所有写操作：修改内存状态后立即原子落盘
+    private func mutate(_ body: (inout FileFormat) -> Void) {
+        lock.lock()
+        body(&fileFormat)
+        saveLocked()
+        lock.unlock()
+    }
+
+    /// 从磁盘加载。返回 nil 表示文件不存在或两种格式都解析失败。
+    private static func loadFromDisk() -> (format: FileFormat, migrated: Bool)? {
+        let url = credentialsFileURL()
+        guard let data = try? Data(contentsOf: url) else { return nil }
+
+        let decoder = JSONDecoder()
+        // 新格式：账号数组 + 主账号 ID
+        if let format = try? decoder.decode(FileFormat.self, from: data) {
+            return (format, false)
+        }
+        // 旧格式：单个 token，自动迁移为一个账号并设为主账号
+        if let token = try? decoder.decode(KimiOAuthToken.self, from: data), token.isValid {
+            let account = KimiAccount(id: UUID(), alias: nil, token: token, accountIdentifier: nil)
+            return (FileFormat(accounts: [account], primaryAccountID: account.id), true)
+        }
+        return nil
+    }
+
+    /// 原子写入：目录 0700，文件 0600。调用前必须已持有 lock（init 除外）。
+    private func saveLocked() {
+        let url = Self.credentialsFileURL()
+        let directory = url.deletingLastPathComponent()
+
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(fileFormat)
+
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+
+            let tempURL = directory.appendingPathComponent(".\(url.lastPathComponent).tmp.\(ProcessInfo.processInfo.processIdentifier)")
+            try data.write(to: tempURL, options: .atomic)
+
+            if FileManager.default.fileExists(atPath: url.path) {
+                _ = try FileManager.default.replaceItemAt(url, withItemAt: tempURL)
+            } else {
+                try FileManager.default.moveItem(at: tempURL, to: url)
+            }
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        } catch {
+            // 落盘失败不致命：内存状态已更新，下次写入会重试
+        }
+    }
+}

--- a/macOS/KimiCodeBar/KimiCodeBarApp.swift
+++ b/macOS/KimiCodeBar/KimiCodeBarApp.swift
@@ -751,7 +751,7 @@ struct KimiMenu: View {
 
             // 用量卡片
             VStack(spacing: 12) {
-                if model.loginMethod == .oauth && !model.accounts.isEmpty {
+                if model.loginMethod == .oauth && model.accounts.count > 1 {
                     // OAuth 多账号：账号紧凑行列表，点击行展开对应账号的卡片组
                     AccountQuotaListView()
                 } else {
@@ -1497,13 +1497,13 @@ struct AccountQuotaRow: View {
     @ViewBuilder
     private var expandedContent: some View {
         if case .unauthorized = state {
-            // 登录失效：凭证保留，引导到设置-账号重新授权（管理操作在设置页完成）
+            // 登录失效：凭证保留，引导到设置-多账号重新授权（管理操作在设置页完成）
             HStack(spacing: 8) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.red)
 
-                LText("登录失效，请到设置-账号重新授权")
+                LText("登录失效，请到设置-多账号重新授权")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.kimiTextSecondary)
 
@@ -2810,7 +2810,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .basic: return LanguageManager.tr("基本设置")
-        case .accounts: return LanguageManager.tr("账号")
+        case .accounts: return LanguageManager.tr("多账号")
         case .panelCustom: return LanguageManager.tr("面板自定义")
         case .archive: return LanguageManager.tr("自动归档")
         case .skills: return LanguageManager.tr("技能管理")

--- a/macOS/KimiCodeBar/KimiCodeBarApp.swift
+++ b/macOS/KimiCodeBar/KimiCodeBarApp.swift
@@ -1486,9 +1486,9 @@ struct AccountQuotaRow: View {
         .onHover { isHovered = $0 }
         .cursor(.pointingHand)
         .onTapGesture {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isExpanded.toggle()
-            }
+            // 不用动画：MenuBarExtra 面板窗口高度跟随内容变化，SwiftUI 布局动画
+            // 与 macOS 窗口 frame 动画节奏不一致会产生抖动，瞬时切换反而更稳。
+            isExpanded.toggle()
         }
     }
 

--- a/macOS/KimiCodeBar/KimiCodeBarApp.swift
+++ b/macOS/KimiCodeBar/KimiCodeBarApp.swift
@@ -751,31 +751,37 @@ struct KimiMenu: View {
 
             // 用量卡片
             VStack(spacing: 12) {
-                HStack(spacing: 12) {
-                    UsageCard(
-                        title: languageManager.tr("本周用量"),
-                        subtitle: nil,
-                        percentage: model.quota?.weekly.percentage ?? 0,
-                        reset: model.quota?.weekly.timeUntilReset ?? "--",
-                        color: .kimiBlue,
-                        isLoading: model.isLoading
-                    )
+                if model.loginMethod == .oauth && !model.accounts.isEmpty {
+                    // OAuth 多账号：账号紧凑行列表，点击行展开对应账号的卡片组
+                    AccountQuotaListView()
+                } else {
+                    // API Key 模式（或 OAuth 尚无账号）：保持原有卡片布局
+                    HStack(spacing: 12) {
+                        UsageCard(
+                            title: languageManager.tr("本周用量"),
+                            subtitle: nil,
+                            percentage: model.quota?.weekly.percentage ?? 0,
+                            reset: model.quota?.weekly.timeUntilReset ?? "--",
+                            color: .kimiBlue,
+                            isLoading: model.isLoading
+                        )
 
-                    UsageCard(
-                        title: languageManager.tr("5小时用量"),
-                        subtitle: nil,
-                        percentage: model.quota?.fiveHour.percentage ?? 0,
-                        reset: model.quota?.fiveHour.timeUntilReset ?? "--",
-                        color: .orange,
-                        isLoading: model.isLoading
-                    )
-                }
+                        UsageCard(
+                            title: languageManager.tr("5小时用量"),
+                            subtitle: nil,
+                            percentage: model.quota?.fiveHour.percentage ?? 0,
+                            reset: model.quota?.fiveHour.timeUntilReset ?? "--",
+                            color: .orange,
+                            isLoading: model.isLoading
+                        )
+                    }
 
-                if model.showBoosterWalletCard {
-                    BoosterWalletCard(
-                        wallet: model.quota?.boosterWallet,
-                        isLoading: model.isLoading
-                    )
+                    if model.showBoosterWalletCard {
+                        BoosterWalletCard(
+                            wallet: model.quota?.boosterWallet,
+                            isLoading: model.isLoading
+                        )
+                    }
                 }
 
                 // 本机消耗量卡片：扫描本地会话记录（wire.jsonl usage.record）得出 Token 消耗
@@ -1352,6 +1358,193 @@ struct BoosterWalletCard: View {
         return formatCurrency(wallet.monthlyChargeLimitYuan, currency: wallet.currency)
     }
  }
+
+// MARK: - 账号配额区（OAuth 多账号）
+
+/// OAuth 多账号模式下的账号配额区：每个账号一行紧凑摘要，
+/// 点击行展开/收起该账号的完整卡片组（本周/5小时用量 + 加油包）。
+struct AccountQuotaListView: View {
+    @StateObject private var model = KimiCodeBarModel.shared
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ForEach(model.accounts) { account in
+                AccountQuotaRow(
+                    account: account,
+                    isPrimary: account.id == model.primaryAccountID
+                )
+            }
+        }
+    }
+}
+
+/// 单个账号的紧凑行 + 展开后的卡片组。展开状态本地管理：主账号默认展开，其余默认收起。
+struct AccountQuotaRow: View {
+    let account: KimiAccount
+    let isPrimary: Bool
+
+    @StateObject private var model = KimiCodeBarModel.shared
+    @StateObject private var languageManager = LanguageManager.shared
+    @State private var isExpanded: Bool
+    @State private var isHovered = false
+
+    init(account: KimiAccount, isPrimary: Bool) {
+        self.account = account
+        self.isPrimary = isPrimary
+        _isExpanded = State(initialValue: isPrimary)
+    }
+
+    /// 该账号最近一次拉取成功的配额（失败时保留旧值）
+    private var quota: KimiQuota? {
+        model.accountQuotas[account.id]
+    }
+
+    /// 该账号当前加载状态
+    private var state: KimiAccountState {
+        model.accountStates[account.id] ?? .idle
+    }
+
+    private var isLoadingState: Bool {
+        if case .loading = state { return true }
+        return false
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            rowButton
+
+            if isExpanded {
+                expandedContent
+            }
+        }
+    }
+
+    // MARK: 紧凑行
+
+    private var rowButton: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(model.displayName(for: account))
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.kimiTextPrimary)
+
+                    if isPrimary {
+                        LText("主账号")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(Color.kimiBlue)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color.kimiBlue.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+
+                    if case .unauthorized = state {
+                        LText("登录失效")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color.red.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                }
+
+                // 摘要行：失败时显示灰色错误提示，否则展示最近一次成功的配额
+                if case .failed(let message) = state {
+                    Text(message)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.kimiTextTertiary)
+                        .lineLimit(1)
+                } else if let quota {
+                    LText("周 %1$d%% · 5h %2$d%%", quota.weekly.percentage, quota.fiveHour.percentage)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(isHovered ? .kimiTextPrimary : .kimiTextSecondary)
+                } else {
+                    Text("--")
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(isHovered ? .kimiTextPrimary : .kimiTextSecondary)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            if case .loading = state {
+                LoadingRing()
+                    .frame(width: 12, height: 12)
+            }
+
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.kimiTextTertiary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.white.opacity(isHovered ? 0.14 : 0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        .cursor(.pointingHand)
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded.toggle()
+            }
+        }
+    }
+
+    // MARK: 展开卡片组
+
+    @ViewBuilder
+    private var expandedContent: some View {
+        if case .unauthorized = state {
+            // 登录失效：凭证保留，引导到设置-账号重新授权（管理操作在设置页完成）
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.red)
+
+                LText("登录失效，请到设置-账号重新授权")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.kimiTextSecondary)
+
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(Color.red.opacity(0.10))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        } else {
+            VStack(spacing: 8) {
+                HStack(spacing: 12) {
+                    UsageCard(
+                        title: languageManager.tr("本周用量"),
+                        subtitle: nil,
+                        percentage: quota?.weekly.percentage ?? 0,
+                        reset: quota?.weekly.timeUntilReset ?? "--",
+                        color: .kimiBlue,
+                        isLoading: isLoadingState
+                    )
+
+                    UsageCard(
+                        title: languageManager.tr("5小时用量"),
+                        subtitle: nil,
+                        percentage: quota?.fiveHour.percentage ?? 0,
+                        reset: quota?.fiveHour.timeUntilReset ?? "--",
+                        color: .orange,
+                        isLoading: isLoadingState
+                    )
+                }
+
+                if model.showBoosterWalletCard {
+                    BoosterWalletCard(
+                        wallet: quota?.boosterWallet,
+                        isLoading: isLoadingState
+                    )
+                }
+            }
+        }
+    }
+}
 
 // MARK: - Kimi Web 重启提示
 
@@ -2606,6 +2799,7 @@ private func parseNestedFrontMatterValue(_ frontMatter: String, outerKey: String
 
 enum SettingsPane: String, CaseIterable, Identifiable {
     case basic
+    case accounts
     case panelCustom
     case archive
     case skills
@@ -2616,6 +2810,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .basic: return LanguageManager.tr("基本设置")
+        case .accounts: return LanguageManager.tr("账号")
         case .panelCustom: return LanguageManager.tr("面板自定义")
         case .archive: return LanguageManager.tr("自动归档")
         case .skills: return LanguageManager.tr("技能管理")
@@ -2626,6 +2821,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .basic: return "gear"
+        case .accounts: return "person.2"
         case .panelCustom: return "rectangle.3.group"
         case .archive: return "archivebox"
         case .skills: return "puzzlepiece.extension"
@@ -2662,6 +2858,8 @@ struct SettingsRootView: View {
             switch selectedPane {
             case .basic:
                 BasicSettingsView()
+            case .accounts:
+                AccountsSettingsView()
             case .panelCustom:
                 PanelCustomSettingsView()
             case .archive:
@@ -4238,10 +4436,26 @@ final class KimiCodeBarModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var isLoading = false
 
-    @Published var oauthToken: KimiOAuthToken?
     @Published var oauthDeviceAuth: KimiDeviceAuthorization?
     @Published var oauthLoginInProgress = false
     @Published var oauthLoginError: String?
+
+    // MARK: - 多账号（仅 loginMethod == .oauth 时生效）
+
+    /// 账号列表（镜像 KimiAccountStore 的内存状态）
+    @Published var accounts: [KimiAccount] = []
+    /// 主账号 ID：菜单栏文字/图形与面板只展示主账号用量
+    @Published var primaryAccountID: UUID?
+    /// 每个账号最近一次拉取成功的配额（失败时保留旧值）
+    @Published var accountQuotas: [UUID: KimiQuota] = [:]
+    /// 每个账号的加载状态（错误隔离：单账号失败不影响其他账号）
+    @Published var accountStates: [UUID: KimiAccountState] = [:]
+
+    /// 兼容属性：主账号的 token。现有 UI 只读它判断是否已授权。
+    var oauthToken: KimiOAuthToken? {
+        guard let id = primaryAccountID else { return nil }
+        return accounts.first(where: { $0.id == id })?.token
+    }
 
     @Published var kimiVersion: String = LanguageManager.tr("检测中…")
     @Published var isCheckingUpdate: Bool = false
@@ -4284,7 +4498,12 @@ final class KimiCodeBarModel: ObservableObject {
     }
 
     init() {
-        oauthToken = KimiOAuthService.loadStoredToken()
+        // 加载多账号凭证（旧单 token 格式由 store 自动迁移），并保证主账号有效
+        let store = KimiAccountStore.shared
+        store.ensurePrimaryAccount()
+        let snapshot = store.snapshot
+        accounts = snapshot.accounts
+        primaryAccountID = snapshot.primaryAccountID
         refresh(showsLoading: false)
         Task { await loadKimiVersion() }
         startQuotaTimer()
@@ -4320,6 +4539,11 @@ final class KimiCodeBarModel: ObservableObject {
     ///   仅手动点「刷新」按钮时传 true；后台场景（启动、定时器、面板打开、切登录方式、
     ///   设置窗口 onAppear、saveKey）一律传 false，避免界面无谓闪烁。
     func refresh(showsLoading: Bool = true) {
+        // OAuth 模式走多账号并行刷新；以下原逻辑仅服务 API Key 模式
+        guard loginMethod == .token else {
+            refreshAllAccounts(showsLoading: showsLoading)
+            return
+        }
         if showsLoading {
             isLoading = true
         }
@@ -4365,58 +4589,177 @@ final class KimiCodeBarModel: ObservableObject {
         }
     }
 
-    /// 根据当前登录方式解析 Bearer 凭证。
-    /// OAuth 模式下使用 Bar 专属凭证文件（与 CLI 隔离），过期前自动用 refresh_token 换新。
+    /// 解析 API Key 模式下的 Bearer 凭证。
+    /// OAuth 模式不再走这里，按账号维度走 resolveAccessToken(for:)。
     private func resolveBearerToken() async -> String? {
-        switch loginMethod {
-        case .token:
-            return key.isEmpty ? nil : key
-        case .oauth:
-            if let fresh = KimiOAuthService.loadStoredToken() {
-                oauthToken = fresh
-            }
-            guard let token = oauthToken, token.isValid else { return nil }
+        key.isEmpty ? nil : key
+    }
 
-            guard token.needsRefresh else {
-                return token.accessToken
-            }
+    /// 解析单个账号当前可用的 access token。
+    /// 语义与旧单账号逻辑一致（按账号维度）：
+    /// 过期前自动用 refresh_token 换新；刷新前再读一次磁盘，防御其他 Bar 实例刚刷新过；
+    /// 授权被吊销（unauthorized）时返回 nil，由调用方把账号标记为「登录失效」——
+    /// 凭证保留在列表中等待用户重新授权，不删除。
+    private func resolveAccessToken(for accountID: UUID) async -> String? {
+        let store = KimiAccountStore.shared
+        guard let account = store.account(id: accountID), account.token.isValid else { return nil }
+        let token = account.token
 
-            // 刷新前再读一次磁盘：防御其他 Bar 实例刚完成刷新并写入了新凭证
-            if let latest = KimiOAuthService.loadStoredToken(),
-               latest.accessToken != token.accessToken,
-               !latest.needsRefresh {
-                oauthToken = latest
+        guard token.needsRefresh else {
+            return token.accessToken
+        }
+
+        // 刷新前再读一次磁盘：防御其他 Bar 实例刚完成刷新并写入了新凭证
+        if let latest = store.freshAccount(id: accountID)?.token,
+           latest.accessToken != token.accessToken,
+           !latest.needsRefresh {
+            return latest.accessToken
+        }
+
+        let result = await oauthService.refreshAccessToken(token)
+        switch result {
+        case .success(let newToken):
+            store.updateToken(id: accountID, token: newToken)
+            return newToken.accessToken
+        case .failure(.unauthorized):
+            // 若磁盘上已是另一份凭证（其他实例刷新成功），直接沿用
+            if let latest = store.freshAccount(id: accountID)?.token,
+               latest.accessToken != token.accessToken {
                 return latest.accessToken
             }
+            // 授权已被吊销：标记「登录失效」，等待用户重新授权
+            return nil
+        case .failure:
+            // 网络等原因刷新失败，先沿用旧 token 让服务端决定是否拒绝
+            return token.accessToken
+        }
+    }
 
-            let result = await oauthService.refreshAccessToken(token)
-            switch result {
-            case .success(let newToken):
-                KimiOAuthService.saveToken(newToken)
-                oauthToken = newToken
-                return newToken.accessToken
-            case .failure(.unauthorized):
-                // 若磁盘上已是另一份凭证（其他实例刷新成功），直接沿用而不是误删
-                if let latest = KimiOAuthService.loadStoredToken(),
-                   latest.accessToken != token.accessToken {
-                    oauthToken = latest
-                    return latest.accessToken
+    // MARK: - 多账号刷新
+
+    /// 并行刷新全部账号的配额。错误隔离：单账号失败（含登录失效）只标记该账号，
+    /// 不影响其他账号，也不删除任何凭证。完成后把主账号数据同步到兼容属性。
+    func refreshAllAccounts(showsLoading: Bool = true) {
+        if showsLoading {
+            isLoading = true
+        }
+        errorMessage = nil
+
+        let store = KimiAccountStore.shared
+        // 同步磁盘最新状态（含旧格式迁移、其他 Bar 实例的写入）
+        store.reload()
+        store.ensurePrimaryAccount()
+        let snapshot = store.snapshot
+        accounts = snapshot.accounts
+        primaryAccountID = snapshot.primaryAccountID
+
+        guard !snapshot.accounts.isEmpty else {
+            if showsLoading {
+                isLoading = false
+            }
+            accountQuotas = [:]
+            accountStates = [:]
+            syncPrimaryCompat()
+            return
+        }
+
+        // 清掉已删除账号的缓存（例如被其他 Bar 实例删除）
+        let validIDs = Set(snapshot.accounts.map(\.id))
+        accountQuotas = accountQuotas.filter { validIDs.contains($0.key) }
+        accountStates = accountStates.filter { validIDs.contains($0.key) }
+
+        for account in snapshot.accounts {
+            accountStates[account.id] = .loading
+        }
+
+        Task {
+            // quota 与 error 均为 nil 表示「登录失效」（resolveAccessToken 返回 nil）
+            var results: [(UUID, KimiQuota?, QuotaError?)] = []
+            await withTaskGroup(of: (UUID, KimiQuota?, QuotaError?).self) { group in
+                for account in snapshot.accounts {
+                    group.addTask {
+                        guard let accessToken = await self.resolveAccessToken(for: account.id) else {
+                            return (account.id, nil, nil)
+                        }
+                        switch await self.service.fetchQuota(token: accessToken) {
+                        case .success(let quota):
+                            return (account.id, quota, nil)
+                        case .failure(let error):
+                            return (account.id, nil, error)
+                        }
+                    }
                 }
-                // 授权已被吊销，清除本地凭证（仅 Bar 专属文件），等待用户重新授权
-                oauthToken = nil
-                KimiOAuthService.clearToken()
-                return nil
-            case .failure:
-                // 网络等原因刷新失败，先沿用旧 token 让服务端决定是否拒绝
-                return token.accessToken
+                for await item in group {
+                    results.append(item)
+                }
+            }
+
+            await MainActor.run {
+                for (id, quota, error) in results {
+                    if let quota {
+                        self.accountQuotas[id] = quota
+                        self.accountStates[id] = .loaded
+                    } else if let error {
+                        self.accountStates[id] = .failed(self.errorDescription(error))
+                    } else {
+                        self.accountStates[id] = .unauthorized
+                    }
+                }
+                // 同步一次镜像（token 可能已被刷新轮换），并清掉期间被删除账号的缓存
+                let latest = KimiAccountStore.shared.snapshot
+                self.accounts = latest.accounts
+                self.primaryAccountID = latest.primaryAccountID
+                let validIDs = Set(latest.accounts.map(\.id))
+                self.accountQuotas = self.accountQuotas.filter { validIDs.contains($0.key) }
+                self.accountStates = self.accountStates.filter { validIDs.contains($0.key) }
+                if showsLoading {
+                    self.isLoading = false
+                }
+                self.syncPrimaryCompat()
             }
         }
     }
 
-    // MARK: - OAuth 授权登录
+    /// 把主账号数据同步到兼容属性（quota / text / errorMessage），
+    /// 让现有只读这些属性的 UI 在多账号下无需修改即可工作。
+    private func syncPrimaryCompat() {
+        guard loginMethod == .oauth else { return }
+        guard let primaryID = primaryAccountID,
+              accounts.contains(where: { $0.id == primaryID }) else {
+            quota = nil
+            text = LanguageManager.tr("未登录")
+            errorMessage = nil
+            return
+        }
+        if let primaryQuota = accountQuotas[primaryID] {
+            quota = primaryQuota
+            text = LanguageManager.tr("周 %1$d%% · 5h %2$d%%", arguments: [primaryQuota.weekly.percentage, primaryQuota.fiveHour.percentage])
+        } else {
+            quota = nil
+            text = "--"
+        }
+        switch accountStates[primaryID] {
+        case .failed(let message):
+            errorMessage = message
+        case .unauthorized:
+            errorMessage = LanguageManager.tr("授权已失效，请重新登录")
+        default:
+            errorMessage = nil
+        }
+    }
 
-    /// 启动 Device Code Flow：请求设备码 → 打开浏览器 → 后台轮询直至授权完成。
+    // MARK: - OAuth 授权登录（添加账号）
+
+    /// 添加一个账号：启动 Device Code Flow → 打开浏览器 → 后台轮询直至授权完成，
+    /// 成功后尽力去重再加入账号列表。0 账号时即添加第一个账号（自动成为主账号）。
     func startOAuthLogin() {
+        runDeviceAuthorizationFlow { token in
+            await self.finishAddingAccount(token: token)
+        }
+    }
+
+    /// 设备授权流程的公共部分，成功后由 onSuccess 决定 token 的用途（添加账号 / 重新授权）。
+    private func runDeviceAuthorizationFlow(onSuccess: @escaping (KimiOAuthToken) async -> Void) {
         oauthLoginTask?.cancel()
         oauthLoginError = nil
         oauthDeviceAuth = nil
@@ -4450,15 +4793,37 @@ final class KimiCodeBarModel: ObservableObject {
             oauthDeviceAuth = nil
             switch pollResult {
             case .success(let token):
-                KimiOAuthService.saveToken(token)
-                oauthToken = token
-                refresh(showsLoading: false)
+                await onSuccess(token)
             case .failure(let error) where error != .cancelled:
                 oauthLoginError = oauthErrorDescription(error)
             case .failure:
                 break
             }
         }
+    }
+
+    /// 授权成功后收尾：拉一次 usages 尽力提取账号唯一标识做去重，
+    /// 判定重复则丢弃新 token、不新增账号；否则加入列表并刷新。
+    private func finishAddingAccount(token: KimiOAuthToken) async {
+        var identifier: String?
+        if case .success(let quota) = await service.fetchQuota(token: token.accessToken) {
+            identifier = quota.userIdentifier
+        }
+
+        let store = KimiAccountStore.shared
+        if let identifier,
+           store.snapshot.accounts.contains(where: { $0.accountIdentifier == identifier }) {
+            // 重复账号：丢弃新 token
+            oauthLoginError = LanguageManager.tr("该账号已添加，无需重复授权")
+            return
+        }
+
+        store.addAccount(KimiAccount(id: UUID(), alias: nil, token: token, accountIdentifier: identifier))
+        store.ensurePrimaryAccount()
+        let snapshot = store.snapshot
+        accounts = snapshot.accounts
+        primaryAccountID = snapshot.primaryAccountID
+        refresh(showsLoading: false)
     }
 
     func cancelOAuthLogin() {
@@ -4468,15 +4833,81 @@ final class KimiCodeBarModel: ObservableObject {
         oauthLoginInProgress = false
     }
 
-    /// 退出授权登录：取消进行中的授权流程并清除本地凭证。
+    /// 兼容旧「退出登录」语义：多账号下删除当前主账号。
+    /// 主账号被删除后顺延为列表中的下一个账号；无剩余账号时回到未登录态。
     func logoutOAuth() {
         cancelOAuthLogin()
         oauthLoginError = nil
-        oauthToken = nil
-        KimiOAuthService.clearToken()
-        quota = nil
-        text = LanguageManager.tr("未登录")
-        errorMessage = nil
+        if let primaryID = primaryAccountID {
+            removeAccount(primaryID)
+        }
+    }
+
+    // MARK: - 账号管理
+
+    /// 删除账号：移除凭证与该账号的配额/状态缓存。
+    /// 删除主账号时，主账号顺延为原列表中排在其后的账号（其后无账号则取第一个）。
+    func removeAccount(_ id: UUID) {
+        let store = KimiAccountStore.shared
+        let removedIndex = accounts.firstIndex(where: { $0.id == id })
+        let wasPrimary = (primaryAccountID == id)
+
+        store.removeAccount(id: id)
+        let remaining = store.snapshot.accounts
+        if wasPrimary, let removedIndex, remaining.indices.contains(removedIndex) {
+            store.setPrimaryAccount(remaining[removedIndex].id)
+        }
+        store.ensurePrimaryAccount()
+
+        let snapshot = store.snapshot
+        accounts = snapshot.accounts
+        primaryAccountID = snapshot.primaryAccountID
+        accountQuotas.removeValue(forKey: id)
+        accountStates.removeValue(forKey: id)
+        syncPrimaryCompat()
+    }
+
+    /// 重命名账号别名；传 nil 或空白字符串表示清除别名（回退显示「账号 N」）
+    func renameAccount(_ id: UUID, alias: String?) {
+        let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
+        KimiAccountStore.shared.setAlias(id: id, alias: (trimmed?.isEmpty == false) ? trimmed : nil)
+        accounts = KimiAccountStore.shared.snapshot.accounts
+    }
+
+    /// 设置主账号：菜单栏文字/图形与兼容属性只展示主账号用量
+    func setPrimaryAccount(_ id: UUID) {
+        guard accounts.contains(where: { $0.id == id }) else { return }
+        KimiAccountStore.shared.setPrimaryAccount(id)
+        primaryAccountID = id
+        syncPrimaryCompat()
+    }
+
+    /// 重新授权：对指定账号重走设备授权流程，成功后替换其 token 并更新账号标识。
+    /// 用于「登录失效」的账号恢复；不会删除该账号的别名等其它信息。
+    func reauthorizeAccount(_ id: UUID) {
+        runDeviceAuthorizationFlow { token in
+            var identifier: String?
+            if case .success(let quota) = await self.service.fetchQuota(token: token.accessToken) {
+                identifier = quota.userIdentifier
+            }
+            let store = KimiAccountStore.shared
+            store.updateToken(id: id, token: token)
+            if let identifier {
+                store.updateAccountIdentifier(id: id, identifier: identifier)
+            }
+            self.accounts = store.snapshot.accounts
+            self.accountStates[id] = .idle
+            self.refresh(showsLoading: false)
+        }
+    }
+
+    /// 账号显示名：优先别名，回退「账号 N」（N 为列表中的位置）
+    func displayName(for account: KimiAccount) -> String {
+        if let alias = account.alias?.trimmingCharacters(in: .whitespacesAndNewlines), !alias.isEmpty {
+            return alias
+        }
+        let index = accounts.firstIndex(where: { $0.id == account.id }) ?? 0
+        return LanguageManager.tr("账号 %1$d", arguments: [index + 1])
     }
 
     private func oauthErrorDescription(_ error: KimiOAuthError) -> String {

--- a/macOS/KimiCodeBar/KimiCodeBarQuotaService.swift
+++ b/macOS/KimiCodeBar/KimiCodeBarQuotaService.swift
@@ -37,6 +37,31 @@ struct KimiQuota: Equatable {
     let totalQuota: QuotaDetail
     let membershipLevel: String?
     let boosterWallet: BoosterWallet?
+    /// 账号唯一标识（user 对象中的 id/phone/email，取第一个非空值；都没有则为 nil）。
+    /// 仅用于多账号添加时的尽力去重，界面不展示。
+    let userIdentifier: String?
+}
+
+/// 宽松字符串解析：兼容服务端把标识字段以数字形式返回的情况
+private struct LenientString: Codable {
+    let value: String?
+
+    init(value: String?) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let string = try? container.decode(String.self) {
+            value = string
+        } else if let int = try? container.decode(Int.self) {
+            value = String(int)
+        } else if let double = try? container.decode(Double.self) {
+            value = String(double)
+        } else {
+            value = nil
+        }
+    }
 }
 
 final class KimiCodeBarQuotaService {
@@ -131,6 +156,10 @@ final class KimiCodeBarQuotaService {
                     let level: String?
                 }
                 let membership: Membership?
+                // 账号唯一标识候选字段，宽松解析（服务端可能以数字形式返回 id）
+                let id: LenientString?
+                let phone: LenientString?
+                let email: LenientString?
             }
             struct BoosterWallet: Codable {
                 struct Money: Codable {
@@ -225,7 +254,10 @@ final class KimiCodeBarQuotaService {
             fiveHour: fiveHour,
             totalQuota: totalQuota,
             membershipLevel: membershipLevel,
-            boosterWallet: boosterWallet
+            boosterWallet: boosterWallet,
+            userIdentifier: [resp.user?.id?.value, resp.user?.phone?.value, resp.user?.email?.value]
+                .compactMap { $0 }
+                .first(where: { !$0.isEmpty })
         )
     }
 

--- a/macOS/KimiCodeBar/KimiOAuthService.swift
+++ b/macOS/KimiCodeBar/KimiOAuthService.swift
@@ -330,63 +330,9 @@ final class KimiOAuthService {
         }
     }
 
-    // MARK: Token 持久化
-
-    /// Bar 专属的 token 存储路径。
-    /// 注意：刻意与 KimiCode CLI 的 ~/.kimi-code/credentials/kimi-code.json 隔离，
-    /// Bar 的授权、刷新、退出登录都只操作本文件，绝不读写 CLI 的凭证，
-    /// 避免因 refresh_token 服务端轮换导致 CLI 凭证失效。
-    static func credentialsFileURL() -> URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return appSupport.appendingPathComponent("KimiCodeBar/credentials.json")
-    }
-
-    /// 从磁盘读取 Bar 自己的 token
-    static func loadStoredToken() -> KimiOAuthToken? {
-        let url = credentialsFileURL()
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        guard let token = try? JSONDecoder().decode(KimiOAuthToken.self, from: data) else { return nil }
-        return token.isValid ? token : nil
-    }
-
-    /// 原子写入 token 文件：目录 0700，文件 0600
-    @discardableResult
-    static func saveToken(_ token: KimiOAuthToken) -> Bool {
-        let url = credentialsFileURL()
-        let directory = url.deletingLastPathComponent()
-
-        do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            let data = try encoder.encode(token)
-
-            try FileManager.default.createDirectory(
-                at: directory,
-                withIntermediateDirectories: true,
-                attributes: [.posixPermissions: 0o700]
-            )
-
-            let tempURL = directory.appendingPathComponent(".\(url.lastPathComponent).tmp.\(ProcessInfo.processInfo.processIdentifier)")
-            try data.write(to: tempURL, options: .atomic)
-
-            if FileManager.default.fileExists(atPath: url.path) {
-                _ = try FileManager.default.replaceItemAt(url, withItemAt: tempURL)
-            } else {
-                try FileManager.default.moveItem(at: tempURL, to: url)
-            }
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    static func clearToken() {
-        let url = credentialsFileURL()
-        try? FileManager.default.removeItem(at: url)
-    }
-
     // MARK: 私有解析
+
+    /// 凭证持久化已迁移到 KimiAccountStore（多账号存储），本服务只保留网络职责。
 
     /// 解析 token 响应。登录时响应必含全部字段；刷新时服务端可能省略
     /// refresh_token，由 fallbackRefreshToken 传入旧值兜底。

--- a/macOS/KimiCodeBar/Localizable.xcstrings
+++ b/macOS/KimiCodeBar/Localizable.xcstrings
@@ -420,6 +420,28 @@
         }
       }
     },
+    "为该账号设置一个便于区分的别名，留空则恢复默认名称。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set an alias to distinguish this account. Leave blank to restore the default name."
+          }
+        }
+      }
+    },
+    "主账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primary"
+          }
+        }
+      }
+    },
     "今日" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -541,6 +563,39 @@
         }
       }
     },
+    "删除" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
+    "删除账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Account"
+          }
+        }
+      }
+    },
+    "别名" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alias"
+          }
+        }
+      }
+    },
     "刷新" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -581,6 +636,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Booster Pack Card"
+          }
+        }
+      }
+    },
+    "加载中…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading…"
           }
         }
       }
@@ -823,6 +889,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Appearance"
+          }
+        }
+      }
+    },
+    "多账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multi-Account"
           }
         }
       }
@@ -1718,6 +1795,28 @@
         }
       }
     },
+    "添加账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Account"
+          }
+        }
+      }
+    },
+    "添加账号后，即可在菜单栏查看各账号的配额使用情况" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add an account to view each account's quota usage in the menu bar."
+          }
+        }
+      }
+    },
     "版本 %@" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1784,6 +1883,28 @@
         }
       }
     },
+    "登录失效" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session Expired"
+          }
+        }
+      }
+    },
+    "登录失效，请到设置-多账号重新授权" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session expired. Go to Settings > Multi-Account to re-authorize."
+          }
+        }
+      }
+    },
     "登录方式" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1802,6 +1923,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
+          }
+        }
+      }
+    },
+    "确定删除「%1$@」吗？只会删除 Bar 中保存的授权，不影响 Kimi CLI 的登录状态。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to delete “%1$@”? This only removes the authorization saved in the Bar and does not affect Kimi CLI sign-in."
           }
         }
       }
@@ -1971,6 +2103,17 @@
         }
       }
     },
+    "设为主账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set as Primary"
+          }
+        }
+      }
+    },
     "设置" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1978,6 +2121,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Settings"
+          }
+        }
+      }
+    },
+    "该账号已添加，无需重复授权" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This account has already been added. No need to authorize again."
           }
         }
       }
@@ -2000,6 +2154,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Invalid request URL"
+          }
+        }
+      }
+    },
+    "账号 %1$d" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account %1$d"
+          }
+        }
+      }
+    },
+    "账号仅用于在 Bar 中查看配额，不影响 Kimi CLI 的登录状态。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accounts are only used to view quotas in the Bar and do not affect Kimi CLI sign-in."
+          }
+        }
+      }
+    },
+    "账号列表" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account List"
           }
         }
       }
@@ -2070,6 +2257,17 @@
         }
       }
     },
+    "还没有添加账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Accounts Added Yet"
+          }
+        }
+      }
+    },
     "进阶版" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2114,6 +2312,17 @@
         }
       }
     },
+    "通过浏览器授权添加一个 Kimi 账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize in your browser to add a Kimi account."
+          }
+        }
+      }
+    },
     "重启" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2132,6 +2341,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Restart to Update"
+          }
+        }
+      }
+    },
+    "重命名" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename"
+          }
+        }
+      }
+    },
+    "重命名账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Account"
+          }
+        }
+      }
+    },
+    "重新授权" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Re-authorize"
           }
         }
       }
@@ -2198,248 +2440,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Default"
-          }
-        }
-      }
-    },
-    "账号 %1$d" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Account %1$d"
-          }
-        }
-      }
-    },
-    "该账号已添加，无需重复授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This account has already been added. No need to authorize again."
-          }
-        }
-      }
-    },
-    "账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accounts"
-          }
-        }
-      }
-    },
-    "账号列表" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Account List"
-          }
-        }
-      }
-    },
-    "主账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primary"
-          }
-        }
-      }
-    },
-    "登录失效" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Session Expired"
-          }
-        }
-      }
-    },
-    "登录失效，请到设置-账号重新授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Session expired. Go to Settings > Accounts to re-authorize."
-          }
-        }
-      }
-    },
-    "加载中…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading…"
-          }
-        }
-      }
-    },
-    "重新授权" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Re-authorize"
-          }
-        }
-      }
-    },
-    "设为主账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set as Primary"
-          }
-        }
-      }
-    },
-    "重命名" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename"
-          }
-        }
-      }
-    },
-    "重命名账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename Account"
-          }
-        }
-      }
-    },
-    "别名" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alias"
-          }
-        }
-      }
-    },
-    "为该账号设置一个便于区分的别名，留空则恢复默认名称。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set an alias to distinguish this account. Leave blank to restore the default name."
-          }
-        }
-      }
-    },
-    "删除" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
-          }
-        }
-      }
-    },
-    "删除账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Account"
-          }
-        }
-      }
-    },
-    "确定删除「%1$@」吗？只会删除 Bar 中保存的授权，不影响 Kimi CLI 的登录状态。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure you want to delete “%1$@”? This only removes the authorization saved in the Bar and does not affect Kimi CLI sign-in."
-          }
-        }
-      }
-    },
-    "还没有添加账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Accounts Added Yet"
-          }
-        }
-      }
-    },
-    "添加账号后，即可在菜单栏查看各账号的配额使用情况" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add an account to view each account's quota usage in the menu bar."
-          }
-        }
-      }
-    },
-    "添加账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Account"
-          }
-        }
-      }
-    },
-    "通过浏览器授权添加一个 Kimi 账号" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorize in your browser to add a Kimi account."
-          }
-        }
-      }
-    },
-    "账号仅用于在 Bar 中查看配额，不影响 Kimi CLI 的登录状态。" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accounts are only used to view quotas in the Bar and do not affect Kimi CLI sign-in."
           }
         }
       }

--- a/macOS/KimiCodeBar/Localizable.xcstrings
+++ b/macOS/KimiCodeBar/Localizable.xcstrings
@@ -2201,6 +2201,248 @@
           }
         }
       }
+    },
+    "账号 %1$d" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account %1$d"
+          }
+        }
+      }
+    },
+    "该账号已添加，无需重复授权" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This account has already been added. No need to authorize again."
+          }
+        }
+      }
+    },
+    "账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accounts"
+          }
+        }
+      }
+    },
+    "账号列表" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account List"
+          }
+        }
+      }
+    },
+    "主账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primary"
+          }
+        }
+      }
+    },
+    "登录失效" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session Expired"
+          }
+        }
+      }
+    },
+    "登录失效，请到设置-账号重新授权" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session expired. Go to Settings > Accounts to re-authorize."
+          }
+        }
+      }
+    },
+    "加载中…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading…"
+          }
+        }
+      }
+    },
+    "重新授权" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Re-authorize"
+          }
+        }
+      }
+    },
+    "设为主账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set as Primary"
+          }
+        }
+      }
+    },
+    "重命名" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename"
+          }
+        }
+      }
+    },
+    "重命名账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Account"
+          }
+        }
+      }
+    },
+    "别名" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alias"
+          }
+        }
+      }
+    },
+    "为该账号设置一个便于区分的别名，留空则恢复默认名称。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set an alias to distinguish this account. Leave blank to restore the default name."
+          }
+        }
+      }
+    },
+    "删除" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
+    "删除账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Account"
+          }
+        }
+      }
+    },
+    "确定删除「%1$@」吗？只会删除 Bar 中保存的授权，不影响 Kimi CLI 的登录状态。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to delete “%1$@”? This only removes the authorization saved in the Bar and does not affect Kimi CLI sign-in."
+          }
+        }
+      }
+    },
+    "还没有添加账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Accounts Added Yet"
+          }
+        }
+      }
+    },
+    "添加账号后，即可在菜单栏查看各账号的配额使用情况" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add an account to view each account's quota usage in the menu bar."
+          }
+        }
+      }
+    },
+    "添加账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Account"
+          }
+        }
+      }
+    },
+    "通过浏览器授权添加一个 Kimi 账号" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize in your browser to add a Kimi account."
+          }
+        }
+      }
+    },
+    "账号仅用于在 Bar 中查看配额，不影响 Kimi CLI 的登录状态。" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accounts are only used to view quotas in the Bar and do not affect Kimi CLI sign-in."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"


### PR DESCRIPTION
## 功能概述

支持在 Bar 中同时监控多个 Kimi 账号的配额，纯只读，与 Kimi CLI 凭证完全隔离。

## 主要改动

- **多账号数据层**：凭证存储升级为「账号数组 + 主账号 ID」，旧单账号格式自动迁移；并行刷新、错误隔离（单账号失效不影响其他账号）、添加时尽力去重
- **面板账号区**：账号紧凑行列表（别名 + 周% + 5h% + 状态），点击展开完整用量卡片，主账号带标记并默认展开
- **设置-账号页**：新增账号管理面板，支持添加（OAuth 设备授权）、设主账号、重命名、删除、失效账号重新授权
- **菜单栏**：保持只显示主账号用量，格式不变
- **兼容性**：API Key 登录方式原样保留；新增 20 条英文翻译

## 验证

- xcodebuild 编译通过（未运行 App，建议实际运行验证面板展开/收起交互与授权引导流程）