### PR TITLE
fix: 菜单栏文字改为模板图以适配明暗菜单栏外观

### DIFF
--- a/macOS/KimiCodeBar/KimiCodeBarApp.swift
+++ b/macOS/KimiCodeBar/KimiCodeBarApp.swift
@@ -3325,6 +3325,7 @@ struct BasicSettingsView: View {
                                     weekly: quota.weekly.percentage,
                                     fiveHour: quota.fiveHour.percentage
                                 ))
+                                .foregroundStyle(.white)
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 6)
                                 .background(Color.black)

--- a/macOS/KimiCodeBar/KimiCodeBarApp.swift
+++ b/macOS/KimiCodeBar/KimiCodeBarApp.swift
@@ -220,7 +220,8 @@ enum MenuBarDisplayScheme: String, CaseIterable, Identifiable {
 
 @MainActor
 enum MenuBarTextRenderer {
-    private static let textColor = Color(red: 0.886, green: 0.910, blue: 0.961)
+    // 模板图只读取 alpha 通道，实际染色由系统按菜单栏明暗外观决定，此处颜色只需保证不透明
+    private static let textColor = Color.black
 
     static func image(scheme: MenuBarDisplayScheme, weekly: Int, fiveHour: Int) -> NSImage {
         switch scheme {
@@ -323,7 +324,7 @@ enum MenuBarTextRenderer {
         guard let nsImage = renderer.nsImage else {
             return NSImage(size: NSSize(width: 56, height: 22))
         }
-        nsImage.isTemplate = false
+        nsImage.isTemplate = true
         return nsImage
     }
 }


### PR DESCRIPTION
## 问题
菜单栏文字颜色硬编码为浅色 (0.886, 0.910, 0.961) 且渲染图未启用模板模式，浅色菜单栏外观（浅色壁纸）下文字几乎不可读。

## 修改
- MenuBarTextRenderer 渲染文字改用不透明黑色（模板图只读取 alpha 通道，实际染色由系统完成）。
- 渲染结果设置 isTemplate = true，由系统按菜单栏实际明暗外观自动染色，同时自动适配桌面着色与高对比度模式。
- 设置面板「实时预览」的预览图补充 .foregroundStyle(.white)，避免模板化后浅色外观下预览变成黑底黑字。
- 三种显示样式（默认 / K 前缀 / 单行）布局不变。

## 验证
- xcodebuild build 编译通过。
- 本地运行确认浅色菜单栏下文字为深色可读，深色菜单栏下为浅色，切换外观自动跟随；设置面板预览显示正常。